### PR TITLE
Separate  component  travel button

### DIFF
--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -1,0 +1,28 @@
+import { Button, Box, Icon } from "@chakra-ui/react";
+import { transportIcon } from "../../utils/constants";
+
+export function TravelMethodButton({ handleTransPortMode, mode, ind }) {
+  return (
+    <Button
+      fontSize={["12px", "16px"]}
+      color="#044B7F"
+      height={["100px", "80px"]}
+      width={["91.67px", "150px"]}
+      border="1px"
+      onChange={handleTransPortMode}
+      colorScheme="#044B7F"
+      value={mode}
+    >
+      <Box
+        pos="absolute"
+        width={["30px", "32px"]}
+        height={["30px", "32px"]}
+        fontSize={"16px"}
+        mb={"22px"}
+      >
+        <Icon as={transportIcon[ind]} />
+      </Box>
+      {mode}
+    </Button>
+  );
+}

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -1,0 +1,50 @@
+import { Box, Button, Text, SimpleGrid, Icon, Flex } from '@chakra-ui/react';
+
+export function TravelMethodButtons({
+  transportIcon,
+  modesOfTransport,
+  handleTransportMode,
+  transportMode,
+}) {
+  return (
+    <SimpleGrid
+      columns={3}
+      defaultValue={transportMode}
+      id="selector"
+      width={['305px', '548px']}
+      mr={'auto'}
+      ml={'auto'}
+    >
+      {modesOfTransport.map((mode, i) => (
+        <Box height="80px" textAlign={'center'} key={mode}>
+          {/* buttons */}
+
+          <Button
+            variant="outline"
+            fontSize={[13, 15]}
+            color="#044B7F"
+            height={['58px', '57px']}
+            width={['91.67px', '141px']}
+            border="1px"
+            // borderColor="044B7F.300"
+            onChange={handleTransportMode}
+            colorScheme="#044B7F"
+            value={mode}
+          >
+            <Box
+              pos="absolute"
+              top={['3px', '2px']}
+              pb={['4px', '3px']}
+              width={['30px', '32px']}
+              height={['30px', '32px']}
+              mb="12px"
+            >
+              <Icon as={transportIcon[i]} />
+            </Box>
+            {mode}
+          </Button>
+        </Box>
+      ))}
+    </SimpleGrid>
+  );
+}

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -1,6 +1,6 @@
-import { Box, Button, Text, SimpleGrid, Icon, Flex } from '@chakra-ui/react';
+import { Box, Button, Text, SimpleGrid, Icon, Flex } from "@chakra-ui/react";
 
-export function TravelMethodButtons({
+export function TravelMethodButtonsContainer({
   transportIcon,
   modesOfTransport,
   handleTransportMode,
@@ -11,32 +11,31 @@ export function TravelMethodButtons({
       columns={3}
       defaultValue={transportMode}
       id="selector"
-      width={['305px', '548px']}
-      mr={'auto'}
-      ml={'auto'}
+      width={["305px", "548px"]}
+      mr={"auto"}
+      ml={"auto"}
     >
       {modesOfTransport.map((mode, i) => (
-        <Box height="80px" textAlign={'center'} key={mode}>
+        <Box height="80px" textAlign={"center"} key={mode}>
           {/* buttons */}
 
           <Button
             variant="outline"
             fontSize={[13, 15]}
             color="#044B7F"
-            height={['58px', '57px']}
-            width={['91.67px', '141px']}
+            height={["58px", "57px"]}
+            width={["91.67px", "141px"]}
             border="1px"
-            // borderColor="044B7F.300"
             onChange={handleTransportMode}
             colorScheme="#044B7F"
             value={mode}
           >
             <Box
               pos="absolute"
-              top={['3px', '2px']}
-              pb={['4px', '3px']}
-              width={['30px', '32px']}
-              height={['30px', '32px']}
+              top={["3px", "2px"]}
+              pb={["4px", "3px"]}
+              width={["30px", "32px"]}
+              height={["30px", "32px"]}
               mb="12px"
             >
               <Icon as={transportIcon[i]} />

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -1,10 +1,8 @@
 import { Flex, Box, Button, SimpleGrid, Icon } from "@chakra-ui/react";
+import { modesOfTransport } from "../../utils/constants";
+import { transportIcon } from "../../utils/constants";
 
-export function TravelMethodButtons({
-  transportIcon,
-  modesOfTransport,
-  handleTransportMode,
-}) {
+export function TravelMethodButtons({ handleTransportMode }) {
   return (
     <Flex width={"fit container "}>
       <SimpleGrid

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -4,12 +4,10 @@ export function TravelMethodButtonsContainer({
   transportIcon,
   modesOfTransport,
   handleTransportMode,
-  transportMode,
 }) {
   return (
     <SimpleGrid
       columns={3}
-      defaultValue={transportMode}
       id="selector"
       width={["305px", "548px"]}
       mr={"auto"}

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -22,27 +22,6 @@ export function TravelMethodButtons({ handleTransPortMode }) {
               mode={mode}
               ind={i}
             />
-            {/* <Button
-              fontSize={["16px", "16px"]}
-              color="#044B7F"
-              height={["100px", "80px"]}
-              width={["91.67px", "150px"]}
-              border="1px"
-              onChange={handleTransportMode}
-              colorScheme="#044B7F"
-              value={mode}
-            >
-              <Box
-                pos="absolute"
-                width={["30px", "32px"]}
-                height={["30px", "32px"]}
-                fontSize={"16px"}
-                mb={"22px"}
-              >
-                <Icon as={transportIcon[i]} />
-              </Box>
-              {mode}
-            </Button> */}
           </Box>
         ))}
       </SimpleGrid>

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -1,8 +1,8 @@
-import { Flex, Box, Button, SimpleGrid, Icon } from "@chakra-ui/react";
+import { Flex, Box, SimpleGrid } from "@chakra-ui/react";
 import { modesOfTransport } from "../../utils/constants";
-import { transportIcon } from "../../utils/constants";
+import { TravelMethodButton } from "./TravelMethodButton";
 
-export function TravelMethodButtons({ handleTransportMode }) {
+export function TravelMethodButtons({ handleTransPortMode }) {
   return (
     <Flex width={"fit container "}>
       <SimpleGrid
@@ -17,8 +17,12 @@ export function TravelMethodButtons({ handleTransportMode }) {
         {modesOfTransport.map((mode, i) => (
           <Box height="80px" textAlign={"center"} key={mode}>
             {/* buttons */}
-
-            <Button
+            <TravelMethodButton
+              handleTransPortMode={handleTransPortMode}
+              mode={mode}
+              ind={i}
+            />
+            {/* <Button
               fontSize={["16px", "16px"]}
               color="#044B7F"
               height={["100px", "80px"]}
@@ -38,7 +42,7 @@ export function TravelMethodButtons({ handleTransportMode }) {
                 <Icon as={transportIcon[i]} />
               </Box>
               {mode}
-            </Button>
+            </Button> */}
           </Box>
         ))}
       </SimpleGrid>

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -1,47 +1,49 @@
-import { Box, Button, Text, SimpleGrid, Icon, Flex } from "@chakra-ui/react";
+import { Flex, Box, Button, SimpleGrid, Icon } from "@chakra-ui/react";
 
-export function TravelMethodButtonsContainer({
+export function TravelMethodButtons({
   transportIcon,
   modesOfTransport,
   handleTransportMode,
 }) {
   return (
-    <SimpleGrid
-      columns={3}
-      id="selector"
-      width={["305px", "548px"]}
-      mr={"auto"}
-      ml={"auto"}
-    >
-      {modesOfTransport.map((mode, i) => (
-        <Box height="80px" textAlign={"center"} key={mode}>
-          {/* buttons */}
+    <Flex width={"fit container "}>
+      <SimpleGrid
+        columns={3}
+        id="selector"
+        width={["305px", "548px"]}
+        height={["345px", "304px"]}
+        mr={"auto"}
+        ml={"auto"}
+        mt={"6px"}
+      >
+        {modesOfTransport.map((mode, i) => (
+          <Box height="80px" textAlign={"center"} key={mode}>
+            {/* buttons */}
 
-          <Button
-            variant="outline"
-            fontSize={[13, 15]}
-            color="#044B7F"
-            height={["58px", "57px"]}
-            width={["91.67px", "141px"]}
-            border="1px"
-            onChange={handleTransportMode}
-            colorScheme="#044B7F"
-            value={mode}
-          >
-            <Box
-              pos="absolute"
-              top={["3px", "2px"]}
-              pb={["4px", "3px"]}
-              width={["30px", "32px"]}
-              height={["30px", "32px"]}
-              mb="12px"
+            <Button
+              fontSize={["16px", "16px"]}
+              color="#044B7F"
+              height={["100px", "80px"]}
+              width={["91.67px", "150px"]}
+              border="1px"
+              onChange={handleTransportMode}
+              colorScheme="#044B7F"
+              value={mode}
             >
-              <Icon as={transportIcon[i]} />
-            </Box>
-            {mode}
-          </Button>
-        </Box>
-      ))}
-    </SimpleGrid>
+              <Box
+                pos="absolute"
+                width={["30px", "32px"]}
+                height={["30px", "32px"]}
+                fontSize={"16px"}
+                mb={"22px"}
+              >
+                <Icon as={transportIcon[i]} />
+              </Box>
+              {mode}
+            </Button>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Flex>
   );
 }


### PR DESCRIPTION
This pull request addressing one of the request in putting from PR 68 to separate the button component .

- The new component "TravelMethodButton" will be rendered in "TravelMethodButttons" .
- 'TravelMethodIcon'  is moved into this new button component . It directly imported into this component .
-  The 'trello' for this task : https://trello.com/c/z50v3GrA/297-dev-travel-method-selection-page

- Please refer to this 'trello' link there is a question need attention to fix the way long text on the button wraps for mobile version. 

ADDITIONAL INFORMATION ****

1. PR68 and PR70 should be reviewed in that order .

2. PR68  should be reviewed first and merge.

3. PR70 to be reviewed and merged after PR68 .