### PR TITLE
link to `form/workArrangement` for 'Start' button

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -75,7 +75,7 @@ export default function Home() {
             This form will take approximately <b>3 minutes</b> to complete.
           </Text>
           <LinkButton
-            href="/form/Question1"
+            href="/form/WorkArrangement"
             onClick={() => sendLogs(logMessage("Start button clicked"))}
             width={["90vw", "173px"]}
           >


### PR DESCRIPTION
this PR relates to the [task for 'Work Arrangement' page](https://trello.com/c/uMT9o9s9), implemented in #72 

Depends on #72 

## What
this PR updates link in the Welcome Page's 'Start' button to take user to the `WorkArrangement` page, the first question in the updated Survey flow (see latest [figma design here](https://www.figma.com/file/Y42AKuHDW46LiLDaTOs6sM/Heroes-carbon-calculator-designs?node-id=978%3A55067) 

## Acceptance Criteria
clicking on the 'Start' button on the [Welcome page](https://github.com/CodeforAustralia/council-emissions-calculator/blob/main/pages/index.js) should lead to the [`WorkArrangement` page](.pages/form/WorkArrangement.jsx), once #72 has been merged into `main` branch
