### PR TITLE
update data model to save wfh days from `WorkFromHomeDays` page

### DIFF
--- a/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
+++ b/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
@@ -81,10 +81,10 @@ export default function DaysOfTheWeekContainer ({
     })
     setDaysOfTheWeek(updatedData);
 
-    // get answer to how many days a week user works
-    const workingDaysNumber = updatedData.filter(item => item.isSelected).length;
+    // get answer to which days of the week user works
+    const workingDays = updatedData.filter(item => item.isSelected).map(x => x.day);
     
-    setNumberOfDays(workingDaysNumber)
+    setNumberOfDays(workingDays)
   }
 
  // NOTE! I use minW attribute for the Box for now because at the moment the layout component has limitation for width. 

--- a/components/FormProvider/FormProvider.jsx
+++ b/components/FormProvider/FormProvider.jsx
@@ -2,10 +2,62 @@ import { useState, createContext } from "react";
 
 export const FormContext = createContext();
 
+// initial state for days of the week has info if it's selected or not (instead of having 2 separate states)
+const daysOfTheWeek = [
+  {
+    id: 0,
+    day: "Monday",
+    isSelected: false,
+    isDisable: false
+  },
+  {
+    id: 1,
+    day: "Tuesday",
+    isSelected: false,
+    isDisable: false
+  },
+  {
+    id: 2,
+    day: "Wednesday",
+    isSelected: false,
+    isDisable: false
+  },
+  {
+    id: 3,
+    day: "Thursday",
+    isSelected: false,
+    isDisable: false
+  },
+  {
+    id: 4,
+    day: "Friday",
+    isSelected: false,
+    isDisable: false
+  },
+  {
+    id: 5,
+    day: "Saturday",
+    isSelected: false,
+    isDisable: false
+  },
+  {
+    id: 6,
+    day: "Sunday",
+    isSelected: false,
+    isDisable: false
+  }
+];
+
 // Example set of answers
 // {
 //     km: 12, // value is an integer
 //     numDaysWorked: 5, // value is an integer from 1-7
+//     wfhDays: ["Wednesday", "Friday", "Saturday"]
+//          // value is a list of length 0-7 containing days of week,
+//          // where respondent worked from home
+//     onsiteDays: ["Monday", "Tuesday"]
+//          // value is a list of length 0-7 containing days of week,
+//          // where respondent worked onsite
 //     travelDays: ["Monday", "Wednesday", "Friday"],
 //          // value is a list of length 0-7 containing days of week
 //     mainTransportMode: "bus",
@@ -19,6 +71,8 @@ export const FormContext = createContext();
 const initialAnswers = {
   km: "",
   numDaysWorked: 0,
+  wfhDays: [],
+  onsiteDays: [],
   travelDays: [],
   workMode: "",
   mainTransportMode: "",

--- a/components/FormProvider/FormProvider.jsx
+++ b/components/FormProvider/FormProvider.jsx
@@ -2,54 +2,9 @@ import { useState, createContext } from "react";
 
 export const FormContext = createContext();
 
-// initial state for days of the week has info if it's selected or not (instead of having 2 separate states)
-const daysOfTheWeek = [
-  {
-    id: 0,
-    day: "Monday",
-    isSelected: false,
-    isDisable: false
-  },
-  {
-    id: 1,
-    day: "Tuesday",
-    isSelected: false,
-    isDisable: false
-  },
-  {
-    id: 2,
-    day: "Wednesday",
-    isSelected: false,
-    isDisable: false
-  },
-  {
-    id: 3,
-    day: "Thursday",
-    isSelected: false,
-    isDisable: false
-  },
-  {
-    id: 4,
-    day: "Friday",
-    isSelected: false,
-    isDisable: false
-  },
-  {
-    id: 5,
-    day: "Saturday",
-    isSelected: false,
-    isDisable: false
-  },
-  {
-    id: 6,
-    day: "Sunday",
-    isSelected: false,
-    isDisable: false
-  }
-];
-
 // Example set of answers
 // {
+//     workMode: "hybrid"  // one of "wfh", "onsite" or "hybrid"
 //     km: 12, // value is an integer
 //     numDaysWorked: 5, // value is an integer from 1-7
 //     wfhDays: ["Wednesday", "Friday", "Saturday"]
@@ -69,18 +24,18 @@ const daysOfTheWeek = [
 // };
 
 const initialAnswers = {
+  workMode: "",
   km: "",
   numDaysWorked: 0,
   wfhDays: [],
   onsiteDays: [],
   travelDays: [],
-  workMode: "",
   mainTransportMode: "",
   incentive: "",
   department: "",
 };
 
-const transactionId = Math.random().toString(36).substr(2, 8);
+const transactionId = Math.random().toString(36).substring(2, 8);
 
 const FormProvider = ({ children }) => {
   const [answers, setAnswers] = useState({ transactionId, ...initialAnswers });

--- a/pages/form/WorkFromHomeDays.jsx
+++ b/pages/form/WorkFromHomeDays.jsx
@@ -13,15 +13,11 @@ import useForm from "../../components/FormProvider";
 
 export default function DaysOfTheWeekSelection() {
 
-  /* previous code for question N1 (will be using it for now till we change FormProvider or the data we collect).
-  Even thought the current data inside container component will show exactly which days the user has worked, 
-  we will only save the number of days
-  */
-
   const { answers, setAnswers } = useForm();
   const [ nDays, setNDays ] = useState(answers.numDaysWorked);
+  const [ wfhDays, setWFHDays ] = useState(answers.wfhDays);
 
-  const saveAnswers = () => setAnswers(prev => ({ ...prev, numDaysWorked: nDays }));
+  const saveAnswers = () => setAnswers(prev => ({ ...prev, numDaysWorked: nDays, wfhDays: wfhDays }));
 
   const router = useRouter();
 
@@ -34,19 +30,16 @@ export default function DaysOfTheWeekSelection() {
       page: router.pathname,
       event: msg,
       ...answers,
-      nWorkDays: nDays,
+      numDaysWorked: wfhDays.concat(answers.onsiteDays).length,
+      wfhDays: wfhDays.join(),
       incentive: incentiveMsg(),
     }
-  }
-
-  // we  pass this function as props to our child component to count humber of days
-  const setNumberOfDays = (days) => {
-    setNDays(days)
   }
 
   // we  pass this function as props to our child component to update Form data and logs
   const saveDataAndShowLog = (logMsg) => {
 
+    setNDays(wfhDays.concat(answers.onsiteDays).length);
     // log to be removed once the project is completed
     // see logs from the number of days the user selected
     console.log(`Data from the child component: ${nDays}`);
@@ -57,12 +50,12 @@ export default function DaysOfTheWeekSelection() {
     sendLogs(logMessage(logMsg));
   }
 
-  /* 
-  !! Hybrid mode 
-  temporary solution - passing dummy data with the dates which were already selected
-  so we can disable them in the component:
-  */
-  const DaysAlreadySelected = [ "Monday", "Tuesday", "Wednesday" ]
+  // TODO: UPDATE THIS
+  // * need a way to have buttons for already selected wfh days to stay selected 
+  //   (but not disabled)
+
+  // disable buttons selected for onsite days
+  const DaysDisabled = answers.onsiteDays;
 
   return (
     <Layout isText={true} Progress={Q1Progress}>
@@ -77,9 +70,9 @@ export default function DaysOfTheWeekSelection() {
         What day(s) do you usually work from home?
       </Heading>
         <DaysOfTheWeekContainer 
-          setNumberOfDays={days => setNumberOfDays(days)}
+          setNumberOfDays={days => setWFHDays(days)}
           saveDataAndLogs={() => saveDataAndShowLog("Next button clicked")}
-          disabledDays={DaysAlreadySelected}
+          disabledDays={DaysDisabled}
           customHref={"/form/Question2"}
         />
     </Layout>


### PR DESCRIPTION
PR addresses [this trello card](https://trello.com/c/KBQFjU1B)

### things to note:
- `setNumberOfDays` from `DaysOfTheWeekContainer` now returns a list of days which user selected as
  working from home, instead of returning the number of days worked
- the calculation for number of days worked is now done on `WorkFromHomeDays` page. Calculation done by summing wfh days and onsite days
- added state vars for `wfhDays` and `onsiteDays` in `components/FormProvider/FormProvider.jsx`

### out of scope:
- when a user revisits the `WorkFromHomeDays` page (by hitting back button), users' previously selected inputs should be shown. We can't test this just yet (until back link button is updated)
