### PR TITLE
Temporary landing page for onSite and Hybrid flows

### DIFF
--- a/pages/form/PageNotFound.jsx
+++ b/pages/form/PageNotFound.jsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { 
+  Box,
+  Heading
+} from "@chakra-ui/react";
+import Layout from "../../components/Layout/Layout";
+import useForm from "../../components/FormProvider";
+import Q1Progress from "../../public/images/progress-bar/q1-progress-dots.svg";
+import Q3Cloud from "../../public/images/clouds/cloud-q3.svg";
+import { BackButton } from "../../components/LinkButton/LinkButton";
+import { useRouter } from "next/router";
+import { sendLogs } from "../../utils/sendLogs";
+
+
+export default function PageNotFound() {
+
+  // code from previoud version below, no changes made
+
+  const { answers, setAnswers } = useForm();
+
+  const saveAnswers = () => {
+    // saving radio button selection
+    setAnswers(prev => ({ ...prev }));
+  }
+
+  const router = useRouter();
+
+  const logMessage = (msg) => {
+    let incentiveMsg = () => {
+      if (!!answers.incentive) {return "<filled>"}
+      else return "<empty>"
+    }
+    return {
+      page: router.pathname,
+      event: msg,
+      ...answers,
+      incentive: incentiveMsg(),
+    }
+  }
+
+  // function to save data and show logs on save
+  const saveDataAndShowLog = (logMsg) => {
+    saveAnswers();
+    sendLogs(logMessage(logMsg));
+  };
+
+  return (
+    <Layout 
+      isText={true} 
+      Progress={Q1Progress}
+    >
+      <Box 
+        pos="absolute" 
+        top={["2", "5"]} 
+        left={["2", "10"]}
+      >
+        <BackButton
+          href="/form/WorkArrangement"
+          onClick={() => {
+            saveDataAndShowLog("Back button clicked");
+          }}
+        />
+      </Box>
+      <Q3Cloud />
+      <Heading 
+        mt={10} 
+        mb={10}
+      >
+      This page is not available right now.
+      </Heading>
+    </Layout>
+  );
+}

--- a/pages/form/WorkArrangement.jsx
+++ b/pages/form/WorkArrangement.jsx
@@ -168,7 +168,7 @@ export default function WorkArrangement() {
           >
             <LinkButton
               disabled={!workMode}
-              href={"/form/DaysOfTheWeekSelection"}
+              href={(workMode === workFromHome) ? "/form/WorkFromHomeDays" : "/form/PageNotFound"}
               width={"105px"}
               topMargin="0"
               H="55px"


### PR DESCRIPTION
Hi team,
* I quickly made a temporary landing page for onSite and Hybrid flows;
* Changed the href for workArrangement page so it leads to the right page and user can see it in the deployed version. 