### PR TITLE
retain selected days in `DaysOfTheWeekContainer` component when revisiting `WorkFromHomeDays` page

### DIFF
--- a/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
+++ b/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Center, Flex, GridItem, SimpleGrid, Text } from "@chakra-ui/react";
 import DaysOfWeekButton from "./DayOfTheWeekButton";
 import LinkButton from "../LinkButton/LinkButton";
+import useForm from "../../components/FormProvider";
 
 export default function DaysOfTheWeekContainer({
   setNumberOfDays,
@@ -9,48 +10,52 @@ export default function DaysOfTheWeekContainer({
   customHref,
   disabledDays,
 }) {
+  const { answers, _ } = useForm();
+  const [ wfhDays, __ ] = useState(answers.wfhDays);
+  const [ onsiteDays, ___ ] = useState(answers.onsiteDays);
+
   // initial state for days of the week has info if it's selected or not (instead of having 2 separate states)
   const [daysOfTheWeek, setDaysOfTheWeek] = useState([
     {
       id: 0,
       day: "Monday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Monday") || onsiteDays.includes("Monday"),
       isDisable: false,
     },
     {
       id: 1,
       day: "Tuesday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Tuesday" || onsiteDays.includes("Tuesday")),
       isDisable: false,
     },
     {
       id: 2,
       day: "Wednesday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Wednesday") || onsiteDays.includes("Wednesday"),
       isDisable: false,
     },
     {
       id: 3,
       day: "Thursday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Thursday") || onsiteDays.includes("Thursday"),
       isDisable: false,
     },
     {
       id: 4,
       day: "Friday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Friday") || onsiteDays.includes("Friday"),
       isDisable: false,
     },
     {
       id: 5,
       day: "Saturday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Saturday") || onsiteDays.includes("Saturday"),
       isDisable: false,
     },
     {
       id: 6,
       day: "Sunday",
-      isSelected: false,
+      isSelected: wfhDays.includes("Sunday") || onsiteDays.includes("Sunday"),
       isDisable: false,
     },
   ]);

--- a/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
+++ b/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
@@ -11,8 +11,8 @@ export default function DaysOfTheWeekContainer({
   disabledDays,
 }) {
   const { answers, _ } = useForm();
-  const [ wfhDays, __ ] = useState(answers.wfhDays);
-  const [ onsiteDays, ___ ] = useState(answers.onsiteDays);
+  const [wfhDays, __] = useState(answers.wfhDays);
+  const [onsiteDays, ___] = useState(answers.onsiteDays);
 
   // initial state for days of the week has info if it's selected or not (instead of having 2 separate states)
   const [daysOfTheWeek, setDaysOfTheWeek] = useState([
@@ -31,13 +31,15 @@ export default function DaysOfTheWeekContainer({
     {
       id: 2,
       day: "Wednesday",
-      isSelected: wfhDays.includes("Wednesday") || onsiteDays.includes("Wednesday"),
+      isSelected:
+        wfhDays.includes("Wednesday") || onsiteDays.includes("Wednesday"),
       isDisable: false,
     },
     {
       id: 3,
       day: "Thursday",
-      isSelected: wfhDays.includes("Thursday") || onsiteDays.includes("Thursday"),
+      isSelected:
+        wfhDays.includes("Thursday") || onsiteDays.includes("Thursday"),
       isDisable: false,
     },
     {
@@ -49,7 +51,8 @@ export default function DaysOfTheWeekContainer({
     {
       id: 5,
       day: "Saturday",
-      isSelected: wfhDays.includes("Saturday") || onsiteDays.includes("Saturday"),
+      isSelected:
+        wfhDays.includes("Saturday") || onsiteDays.includes("Saturday"),
       isDisable: false,
     },
     {
@@ -85,10 +88,12 @@ export default function DaysOfTheWeekContainer({
     setDaysOfTheWeek(updatedData);
 
     // get answer to which days of the week user works
-    const workingDays = updatedData.filter(item => item.isSelected).map(x => x.day);
-    
-    setNumberOfDays(workingDays)
-  }
+    const workingDays = updatedData
+      .filter((item) => item.isSelected)
+      .map((x) => x.day);
+
+    setNumberOfDays(workingDays);
+  };
 
   return (
     <Center

--- a/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
+++ b/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
@@ -25,7 +25,7 @@ export default function DaysOfTheWeekContainer({
     {
       id: 1,
       day: "Tuesday",
-      isSelected: wfhDays.includes("Tuesday" || onsiteDays.includes("Tuesday")),
+      isSelected: wfhDays.includes("Tuesday") || onsiteDays.includes("Tuesday"),
       isDisable: false,
     },
     {
@@ -89,6 +89,7 @@ export default function DaysOfTheWeekContainer({
 
     // get answer to which days of the week user works
     const workingDays = updatedData
+      .filter((item) => item.isDisable === false)
       .filter((item) => item.isSelected)
       .map((x) => x.day);
 
@@ -111,8 +112,6 @@ export default function DaysOfTheWeekContainer({
             fontWeight="500"
             fontSize="18px"
             justify={["center", "left"]}
-            // mt={["100px", "20px"]}
-
             mt={20}
           >
             Select days of the week *
@@ -140,9 +139,8 @@ export default function DaysOfTheWeekContainer({
           <LinkButton
             width={["305px", "105px"]}
             height={["60px", "54.37px"]}
-            disabled={!daysOfTheWeek.find((item) => item.isSelected)}
+            disabled={!daysOfTheWeek.some((item) => item.isSelected && !item.isDisable)}
             href={customHref}
-            // width={"105px"}
             topMargin="0"
             H="55px"
             justifySelf="right"


### PR DESCRIPTION
## Overview of the Pull Request:
This PR introduces a bug fix (or maybe it's an improvement).
It allows for previously saved answers (in `answers.wfhDays` and `answers.onsiteDays`) to display as selected buttons in the `DaysOfTheWeekContainer` component of the `WorkFromHomeDays` page.

When a user revisits the `WorkFromHomeDays` page (by hitting the 'Back' button), user should expect to see their previously selected wfh days on the page.

## How Has This Been Tested?
Instructions for testing this PR works as expected in the preview deployment:

### Test 1: Confirm that selected days appear on page when revisiting `WorkFromHomeDays` page
1. go to `form/WorkFromHomeDays` page, make your selection(s), then hit 'Next' button (should currently be taken to `/form/TravelMethod` page)
  - confirm that chosen days are logged correctly in logflare
2. go back to `form/WorkFromHomeDays` page (by clicking Back button in browser, or pressing 'Alt+Back' or 'Cmd+Back' on keyboard). You should see the same day(s) selected on page

### Test 2: Confirm that upon revisiting `WorkFromHomeDays` page, user can modify selected days 
1. go to `form/WorkFromHomeDays` page, make your selection(s), then hit 'Next' button (should currently be taken to `/form/TravelMethod` page)
  - confirm that chosen days are logged correctly in logflare
2. go back to `form/WorkFromHomeDays` page (by clicking Back button in browser, or pressing 'Alt+Back' or 'Cmd+Back' on keyboard). Update your selected days by adding / removing current selections, then hit 'Next' button again.
  - confirm that updated selections are logged correctly in logflare
3. go back to `form/WorkFromHomeDays` page again. The updated selections should be shown correctly on page

### Test 3: Confirm that user cannot proceed to next page unless user has selected at least one day

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
