### PR TITLE
Ensure page sequences for `hybrid`, `onsite` and `wfh` work arrangement flows (up to `TravelMethod` page) are correct

### DIFF
--- a/pages/form/WorkArrangement.jsx
+++ b/pages/form/WorkArrangement.jsx
@@ -29,8 +29,7 @@ export default function WorkArrangement() {
   const saveAnswers = () => {
     if (workMode === "wfh") {
       setAnswers((prev) => ({ ...prev, workMode: workMode, onsiteDays: [] }));
-    } else
-    if (workMode === "onsite") {
+    } else if (workMode === "onsite") {
       setAnswers((prev) => ({ ...prev, workMode: workMode, wfhDays: [] }));
     } else {
       setAnswers((prev) => ({ ...prev, workMode: workMode }));
@@ -54,8 +53,7 @@ export default function WorkArrangement() {
         onsiteDays: [].join(),
         incentive: incentiveMsg(),
       };
-    } else
-    if (workMode === "onsite") {
+    } else if (workMode === "onsite") {
       return {
         page: router.pathname,
         event: msg,

--- a/pages/form/WorkArrangement.jsx
+++ b/pages/form/WorkArrangement.jsx
@@ -27,8 +27,14 @@ export default function WorkArrangement() {
   const [workMode, setWorkMode] = useState(answers.workMode);
 
   const saveAnswers = () => {
-    // saving radio button selection
-    setAnswers((prev) => ({ ...prev, workMode: workMode }));
+    if (workMode === "wfh") {
+      setAnswers((prev) => ({ ...prev, workMode: workMode, onsiteDays: [] }));
+    } else
+    if (workMode === "onsite") {
+      setAnswers((prev) => ({ ...prev, workMode: workMode, wfhDays: [] }));
+    } else {
+      setAnswers((prev) => ({ ...prev, workMode: workMode }));
+    }
   };
 
   const router = useRouter();
@@ -39,13 +45,34 @@ export default function WorkArrangement() {
         return "<filled>";
       } else return "<empty>";
     };
-    return {
-      page: router.pathname,
-      event: msg,
-      ...answers,
-      workMode: workMode,
-      incentive: incentiveMsg(),
-    };
+    if (workMode === "wfh") {
+      return {
+        page: router.pathname,
+        event: msg,
+        ...answers,
+        workMode: workMode,
+        onsiteDays: [].join(),
+        incentive: incentiveMsg(),
+      };
+    } else
+    if (workMode === "onsite") {
+      return {
+        page: router.pathname,
+        event: msg,
+        ...answers,
+        workMode: workMode,
+        wfhDays: [].join(),
+        incentive: incentiveMsg(),
+      };
+    } else {
+      return {
+        page: router.pathname,
+        event: msg,
+        ...answers,
+        workMode: workMode,
+        incentive: incentiveMsg(),
+      };
+    }
   };
 
   // function to save data and show logs on save
@@ -58,7 +85,11 @@ export default function WorkArrangement() {
     let href = "";
     switch (workArrangement) {
       case "wfh":
+      case "hybrid":
         href = "/form/WorkFromHomeDays";
+        break;
+      case "onsite":
+        href = "/form/WorkOnSiteDays";
         break;
       default:
         href = "/form/PageNotFound";

--- a/pages/form/WorkFromHomeDays.jsx
+++ b/pages/form/WorkFromHomeDays.jsx
@@ -17,7 +17,7 @@ export default function DaysOfTheWeekSelection() {
   const [wfhDays, setWFHDays] = useState(answers.wfhDays);
 
   const saveAnswers = () =>
-    setAnswers((prev) => ({ ...prev, numDaysWorked: nDays, wfhDays: wfhDays }));
+    setAnswers((prev) => ({ ...prev, numDaysWorked: wfhDays.concat(answers.onsiteDays).length, wfhDays: wfhDays }));
 
   const router = useRouter();
 
@@ -40,18 +40,28 @@ export default function DaysOfTheWeekSelection() {
   // we  pass this function as props to our child component to update Form data and logs
   const saveDataAndShowLog = (logMsg) => {
     setNDays(wfhDays.concat(answers.onsiteDays).length);
-    // log to be removed once the project is completed
-    // see logs from the number of days the user selected
-    console.log(`Data from the child component: ${nDays}`);
-    // logs for when the button got clicked
-    console.log(logMsg);
-
     saveAnswers();
     sendLogs(logMessage(logMsg));
   };
 
   // disable buttons selected for onsite days
   const DaysDisabled = answers.onsiteDays;
+
+  const getHref = (workArrangement) => {
+    let href = "";
+    switch (workArrangement) {
+      case "wfh":
+      case "onsite":
+        href = "/form/TravelMethod";
+        break;
+      case "hybrid":
+        href = "/form/WorkOnSiteDays";
+        break;
+      default:
+        href = "/form/PageNotFound";
+    }
+    return href;
+  };
 
   return (
     <Layout isText={true} Progress={Q1Progress}>
@@ -69,7 +79,7 @@ export default function DaysOfTheWeekSelection() {
         setNumberOfDays={(days) => setWFHDays(days)}
         saveDataAndLogs={() => saveDataAndShowLog("Next button clicked")}
         disabledDays={DaysDisabled}
-        customHref={"/form/WorkOnSiteDays"} //TODO: ENSURE LINK TO NEXT PAGE IS CORRECT!
+        customHref={getHref(answers.workMode)}
       />
     </Layout>
   );

--- a/pages/form/WorkFromHomeDays.jsx
+++ b/pages/form/WorkFromHomeDays.jsx
@@ -17,7 +17,11 @@ export default function DaysOfTheWeekSelection() {
   const [wfhDays, setWFHDays] = useState(answers.wfhDays);
 
   const saveAnswers = () =>
-    setAnswers((prev) => ({ ...prev, numDaysWorked: wfhDays.concat(answers.onsiteDays).length, wfhDays: wfhDays }));
+    setAnswers((prev) => ({
+      ...prev,
+      numDaysWorked: wfhDays.concat(answers.onsiteDays).length,
+      wfhDays: wfhDays,
+    }));
 
   const router = useRouter();
 

--- a/pages/form/WorkOnSiteDays.jsx
+++ b/pages/form/WorkOnSiteDays.jsx
@@ -19,7 +19,7 @@ export default function WorkOnSiteDays() {
   const saveAnswers = () =>
     setAnswers((prev) => ({
       ...prev,
-      numDaysWorked: nDays,
+      numDaysWorked: onsiteDays.concat(answers.wfhDays).length,
       onsiteDays: onsiteDays,
     }));
 
@@ -44,11 +44,6 @@ export default function WorkOnSiteDays() {
   // we  pass this function as props to our child component to update Form data and logs
   const saveDataAndShowLog = (logMsg) => {
     setNDays(onsiteDays.concat(answers.wfhDays).length);
-    // log to be removed once the project is completed
-    // see logs from the number of days the user selected
-    console.log(`Data from the child component: ${nDays}`);
-    // logs for when the button got clicked
-    console.log(logMsg);
 
     saveAnswers();
     sendLogs(logMessage(logMsg));
@@ -73,7 +68,7 @@ export default function WorkOnSiteDays() {
         setNumberOfDays={(days) => setOnsiteDays(days)}
         saveDataAndLogs={() => saveDataAndShowLog("Next button clicked")}
         disabledDays={DaysDisabled}
-        customHref={"/form/TravelMethod"} //TODO: ENSURE LINK TO NEXT PAGE IS CORRECT!
+        customHref={"/form/TravelMethod"}
       />
     </Layout>
   );


### PR DESCRIPTION
## Overview of the Pull Request:
This PR updates the 'Next button' links for `WorkArrangement`, `WorkFromHomeDays`, and `WorkOnSiteDays` pages so that the page sequences align with the 3 work arrangement flows (`hybrid`, `onsite` and `wfh`) as defined in the Figma designs

## link to Trello card or Github issue
https://trello.com/c/vOtejFwk

## How Has This Been Tested?

Reviewers should test the survey in the preview deployment up to `TravelMethods` page to ensure that the Acceptance Criterias listed in the Trello Cards have been addressed.

### AC1: (`hybrid` flow) When user selects 'I spend some days working on-site' on the `WorkArrangement` page: 
- user should not be able to proceed to next page unless he/she has made a selection on current page
- when user clicks 'Next' on the `WorkArrangement` page, user should be presented with `WorkFromHomeDays` page
- when user clicks 'Next' on the `WorkFromHomeDays` page, user should be presented with `WorkOnSiteDays` page
- when user clicks 'Next' on the `WorkOnSiteDays` page, user should be presented with `TravelMethod` page

### AC2: (`onsite` flow) When user selects 'I work fully on-site' on the `WorkArrangement` page: 
- user should not be able to proceed to next page unless he/she has made a selection on current page
- when user clicks 'Next' on the `WorkArrangement` page, user should be presented with `WorkOnSiteDays` page
- when user clicks 'Next' on the `WorkOnSiteDays` page, user should be presented with `TravelMethod` page

### AC3: (`wfh` flow) When user selects 'I work fully from home' on the `WorkArrangement` page: 
- user should not be able to proceed to next page unless he/she has made a selection on current page
- when user clicks 'Next' on the `WorkArrangement` page, user should be presented with `WorkFromHomeDays` page
- when user clicks 'Next' on the `WorkFromHomeDays` page, user should be presented with `TravelMethod` page

### AC4: Ensure the responses saved in data model are updated to reflect the work flow chosen
check for the following in logflare logs:
- when `workMode: onsite`, any selections saved in `wfhDays` should be cleared
- when `workMode: wfh`, any selections saved in `onsiteDays` should be cleared
- check that `numDaysWorked` value add up.

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
