### PR TITLE
Fix `numDaysWorked` calculation in `WorkArrangement` page

### DIFF
--- a/pages/form/WorkArrangement.jsx
+++ b/pages/form/WorkArrangement.jsx
@@ -28,9 +28,19 @@ export default function WorkArrangement() {
 
   const saveAnswers = () => {
     if (workMode === "wfh") {
-      setAnswers((prev) => ({ ...prev, workMode: workMode, numDaysWorked: answers.wfhDays.length, onsiteDays: [] }));
+      setAnswers((prev) => ({
+        ...prev,
+        workMode: workMode,
+        numDaysWorked: answers.wfhDays.length,
+        onsiteDays: [],
+      }));
     } else if (workMode === "onsite") {
-      setAnswers((prev) => ({ ...prev, workMode: workMode, numDaysWorked: answers.onsiteDays.length, wfhDays: [] }));
+      setAnswers((prev) => ({
+        ...prev,
+        workMode: workMode,
+        numDaysWorked: answers.onsiteDays.length,
+        wfhDays: [],
+      }));
     } else {
       setAnswers((prev) => ({ ...prev, workMode: workMode }));
     }

--- a/pages/form/WorkArrangement.jsx
+++ b/pages/form/WorkArrangement.jsx
@@ -28,9 +28,9 @@ export default function WorkArrangement() {
 
   const saveAnswers = () => {
     if (workMode === "wfh") {
-      setAnswers((prev) => ({ ...prev, workMode: workMode, onsiteDays: [] }));
+      setAnswers((prev) => ({ ...prev, workMode: workMode, numDaysWorked: answers.wfhDays.length, onsiteDays: [] }));
     } else if (workMode === "onsite") {
-      setAnswers((prev) => ({ ...prev, workMode: workMode, wfhDays: [] }));
+      setAnswers((prev) => ({ ...prev, workMode: workMode, numDaysWorked: answers.onsiteDays.length, wfhDays: [] }));
     } else {
       setAnswers((prev) => ({ ...prev, workMode: workMode }));
     }
@@ -50,6 +50,7 @@ export default function WorkArrangement() {
         event: msg,
         ...answers,
         workMode: workMode,
+        numDaysWorked: answers.wfhDays.length,
         onsiteDays: [].join(),
         incentive: incentiveMsg(),
       };
@@ -59,6 +60,7 @@ export default function WorkArrangement() {
         event: msg,
         ...answers,
         workMode: workMode,
+        numDaysWorked: answers.onsiteDays.length,
         wfhDays: [].join(),
         incentive: incentiveMsg(),
       };


### PR DESCRIPTION
## Overview of the Pull Request:
The changes in this PR recalculates the total number of days worked (stored in `answers.numDaysWorked`) in the `WorkArrangement` page

### Why recalculate `numDaysWorked` value?
- if a user changes their work arrangement selection (e.g, from `hybrid` to `onsite`), the total number of days worked will need to be recalculated to reflect the new work arrangement selection
- the updated `numDaysWorked` value will also need to be saved to data model (`answers`), and reflected in the log message in logflare

## How Has This Been Tested?
Use logflare to verify that the changes in this PR works as expected:
1. using the preview deployment, fill in the survey (up to `/form/TravelMethod` page) using the following details:
  - in `WorkArrangement` page, select '___I work fully from home___', then click 'Next'
  - in `WorkFromHomeDays` select 'Monday' and 'Friday', then click 'Next'. In logflare, you should a log message similar to the screenshot below:
  ![image](https://user-images.githubusercontent.com/4408259/163753328-71ce8651-a39a-40d9-9c1c-ee9fb1e7ee0c.png)
2. Click the 'Back' button until you're back at `WorkArrangement` page, then perform the following changes:
  - in `WorkArrangement` page, select '___I work fully from home___', then click 'Next'. In logflare, you should see a log message similar to this screenshot:
  ![image](https://user-images.githubusercontent.com/4408259/163753563-272f86b4-a262-44dd-9319-f24350639d53.png)
    - notice that now `workMode=onsite`, `numDaysWorked` has been updated, and `wfhDays` has been cleared
  - in `WorkOnSiteDays` page, select 'Monday`, 'Tuesday', 'Wednesday', then click 'Next'. In logflare, you should see a log message similar to this screenshot:
  ![image](https://user-images.githubusercontent.com/4408259/163753867-c52766e6-7d96-4a32-aa59-e27609e49546.png)
    - notice that `numDaysWorked` and `onsiteDays` has been updated 
3. perform a similar test with `onsite` and `hybrid` work arrangements

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
