### PR TITLE
small refactor: rename all references of `modesOfTransport` to `TravelMethods`

### DIFF
--- a/components/FormProvider/FormProvider.jsx
+++ b/components/FormProvider/FormProvider.jsx
@@ -16,7 +16,7 @@ export const FormContext = createContext();
 //     travelDays: ["Monday", "Wednesday", "Friday"],
 //          // value is a list of length 0-7 containing days of week
 //     mainTransportMode: "bus",
-//          // value is a string containing a transport mode from `modesOfTransport` list (in constants.js)
+//          // value is a string containing a transport mode from `travelMethods` list (in constants.js)
 //     incentive: "I'd like to have better biking lanes.",
 //          // value is a free text string
 //     department: "Education",

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -3,7 +3,7 @@ import {
   Text,
   SimpleGrid,
 } from "@chakra-ui/react";
-import { modesOfTransport } from "../../utils/constants";
+import { travelMethods } from "../../utils/constants";
 import CarpoolCounter from "./CarpoolCounter";
 import TravelMethodButton from "./TravelMethodButton";
 
@@ -24,7 +24,7 @@ const TravelMethodButtons = ({
       {/*ALL travel method button selection */}
      
         <SimpleGrid columns={3} spacingX="20px" spacingY="20px"   >
-          {modesOfTransport.map((mode, i) => (
+          {travelMethods.map((mode, i) => (
             <Flex justify="center" key={i} direction="column" >
               <TravelMethodButton
                 mode={mode}

--- a/pages/form/Question4.jsx
+++ b/pages/form/Question4.jsx
@@ -8,7 +8,7 @@ import {
   Text,
   Flex,
 } from "@chakra-ui/react";
-import { modesOfTransport } from "../../utils/constants";
+import { travelMethods } from "../../utils/constants";
 import Layout from "../../components/Layout/Layout";
 import useForm from "../../components/FormProvider";
 import {
@@ -88,7 +88,7 @@ export default function Question4() {
               defaultValue={transportMode}
               id="selector"
             >
-              {modesOfTransport.map((mode) => (
+              {travelMethods.map((mode) => (
                 <option fontSize="lg" key={mode} value={mode}>
                   {mode}
                 </option>

--- a/pages/form/TravelMethod.jsx
+++ b/pages/form/TravelMethod.jsx
@@ -7,7 +7,7 @@ import useForm from "../../components/FormProvider";
 import TravelMethodButtons from "../../components/TravelMethodButtons/TravelMethodButtons";
 import Q4Progress from "../../public/images/progress-bar/travelMethodSelection-progress-dots.svg";
 
-import { modesOfTransport } from "../../utils/constants";
+import { travelMethods } from "../../utils/constants";
 import Q4Cloud from "../../public/images/clouds/cloud-travelMethodSelection.svg";
 import { sendLogs } from "../../utils/sendLogs";
 
@@ -31,7 +31,7 @@ export default function TravelMethod() {
   );
   const [count, setCount] = useState(0);
   const [status, setStatus] = useState(
-    new Array(modesOfTransport.length).fill(false)
+    new Array(travelMethods.length).fill(false)
   );
 
   const saveAnswers = () =>
@@ -41,7 +41,7 @@ export default function TravelMethod() {
 
   const methodClickHandler = (eventText) => {
   
-    const ind = modesOfTransport.indexOf(eventText);
+    const ind = travelMethods.indexOf(eventText);
    
     const copy = [...status];
     copy[ind] = !copy[ind];

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -17,7 +17,7 @@ export const daysOfWeek = [
   "Sunday",
 ];
 
-export const modesOfTransport = [
+export const travelMethods = [
   "Bicycle",
   "Bus",
   "Carpool",


### PR DESCRIPTION
## Overview of the Pull Request:
This PR is a small refactor to align on our naming convention, which is to refer to the different transport types as 'Travel Methods'.
This change will avoid confusion in future, and will also make it clear that variable name containing 'TravelMethod' are related to the `TravelMethod` page.

## How Has This Been Tested?
Test using the preview deployment that the changes do not change the current functionality of the app. Compare with the [production deployment](https://council-emissions-calculator-spike-flax.vercel.app) that:
- there are no changes to functionality in 'TravelMethod' page
- there are no changes to the page sequences from the 'Welcome' page to 'TravelMethod' page in all 3 work arrangement flows ('wfh', 'onsite', 'hybrid')

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
