### PR TITLE
Refactor Travel Method state management

### DIFF
--- a/components/FormProvider/FormProvider.jsx
+++ b/components/FormProvider/FormProvider.jsx
@@ -30,6 +30,7 @@ const initialAnswers = {
   numDaysWorked: 0,
   wfhDays: [],
   onsiteDays: [],
+  travelMethods: [],
   carpoolPassengerCount: 0,
   travelDays: [],
   mainTransportMode: "",

--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -1,8 +1,8 @@
-import { Button, Text, Icon, Flex, Box,Container } from "@chakra-ui/react";
+import { Box, Button, Flex, Icon, Text } from "@chakra-ui/react";
 import { transportIcon } from "../../utils/constants";
 
-export default function ModeButton({
-  mode,
+export default function TravelMethodButton({
+  name,
   onClick,
   isActive,
   ind,
@@ -33,7 +33,7 @@ export default function ModeButton({
         <Box width="100%" p="0px" mt={1}>
           
           <Text
-    d="inline" 
+            d="inline"
             fontSize="16px"
             fontFamily="Public Sans"
             fontWeight="400"
@@ -41,7 +41,7 @@ export default function ModeButton({
             letterSpacing="0.022em"
       
           >
-            {mode}
+            {name}
           </Text>
          
          

--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -1,21 +1,14 @@
 import { Box, Button, Flex, Icon, Text } from "@chakra-ui/react";
 import { transportIcon } from "../../utils/constants";
 
-export default function TravelMethodButton({
-  name,
-  onClick,
-  isActive,
-  ind,
-}) {
-
+export default function TravelMethodButton({ name, onClick, isActive, ind }) {
   return (
     <Button
       fontSize="16px"
       height={["100px", "80px"]}
       width={["91.67px", "150px"]}
       border="1px"
-     p="0px"
-   
+      p="0px"
       onClick={(e) => onClick(e.target.innerText)}
       variant={isActive ? "solid" : "outline"}
       _active={{ border: "solid" }}
@@ -25,13 +18,9 @@ export default function TravelMethodButton({
       }}
       colorScheme="blue"
     >
-      <Flex justify="center" align="center" direction="column"> 
-        <Icon
-          as={transportIcon[ind]}
-          fontSize={"20px"}
-        />
+      <Flex justify="center" align="center" direction="column">
+        <Icon as={transportIcon[ind]} fontSize={"20px"} />
         <Box width="100%" p="0px" mt={1}>
-          
           <Text
             d="inline"
             fontSize="16px"
@@ -39,12 +28,9 @@ export default function TravelMethodButton({
             fontWeight="400"
             lineHeight="19px"
             letterSpacing="0.022em"
-      
           >
             {name}
           </Text>
-         
-         
         </Box>
       </Flex>
     </Button>

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -3,18 +3,48 @@ import { travelMethods } from "../../utils/constants";
 import CarpoolCounter from "./CarpoolCounter";
 import TravelMethodButton from "./TravelMethodButton";
 import { useState } from "react";
+import useForm from "../../components/FormProvider";
 
-const TravelMethodButtons = ({ methodClickHandler, status }) => {
+const TravelMethodButtons = () => {
+  const { answers, setAnswers } = useForm();
+
   const [travelMethodButtonStates, setTravelMethodButtonStates] = useState(
     travelMethods.map((tm, idx) => {
       return {
         id: idx,
         travelMethod: tm,
-        isSelected: false,
+        isSelected: answers.travelMethods.includes(tm),
         isDisabled: false,
       };
     })
   );
+
+  const handleTravelMethodButtonClick = (buttonName) => {
+    let updatedState = travelMethodButtonStates.map((item) => {
+      if (item.travelMethod === buttonName) {
+        return { ...item, isSelected: !item.isSelected };
+      }
+      else return { ...item };
+    });
+
+    let selectedTravelMethods = updatedState
+      .filter((tm) => tm.isSelected)
+      .map((tm) => tm.travelMethod);
+
+    const updateCarpoolPassengerCount = () => {
+      if (selectedTravelMethods.includes("Carpool")) {
+        if (answers.carpoolPassengerCount === 0) return 1;
+        else return answers.carpoolPassengerCount;
+      }
+      else return 0;
+    };
+
+    setTravelMethodButtonStates(updatedState);
+    setAnswers((prev) => ({ ...prev,
+      travelMethods: selectedTravelMethods,
+      carpoolPassengerCount: updateCarpoolPassengerCount()
+    }));
+  };
 
   return (
     <>
@@ -32,20 +62,20 @@ const TravelMethodButtons = ({ methodClickHandler, status }) => {
       {/*ALL travel method button selection */}
 
       <SimpleGrid columns={3} spacingX="20px" spacingY="20px">
-        {travelMethods.map((mode, i) => (
-          <Flex justify="center" key={i} direction="column">
+        {travelMethodButtonStates.map((item) => (
+          <Flex justify="center" key={item.id} direction="column">
             <TravelMethodButton
-              mode={mode}
-              isActive={status[i]}
-              onClick={methodClickHandler}
-              ind={i}
+              name={item.travelMethod}
+              isActive={item.isSelected}
+              onClick={handleTravelMethodButtonClick}
+              ind={item.id}
             />
           </Flex>
         ))}
       </SimpleGrid>
 
       {/* Carpool counter */}
-      {status[2] && <CarpoolCounter />}
+      {answers.travelMethods.includes("Carpool") && <CarpoolCounter />}
     </>
   );
 };

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -23,8 +23,7 @@ const TravelMethodButtons = () => {
     let updatedState = travelMethodButtonStates.map((item) => {
       if (item.travelMethod === buttonName) {
         return { ...item, isSelected: !item.isSelected };
-      }
-      else return { ...item };
+      } else return { ...item };
     });
 
     let selectedTravelMethods = updatedState
@@ -35,14 +34,14 @@ const TravelMethodButtons = () => {
       if (selectedTravelMethods.includes("Carpool")) {
         if (answers.carpoolPassengerCount === 0) return 1;
         else return answers.carpoolPassengerCount;
-      }
-      else return 0;
+      } else return 0;
     };
 
     setTravelMethodButtonStates(updatedState);
-    setAnswers((prev) => ({ ...prev,
+    setAnswers((prev) => ({
+      ...prev,
       travelMethods: selectedTravelMethods,
-      carpoolPassengerCount: updateCarpoolPassengerCount()
+      carpoolPassengerCount: updateCarpoolPassengerCount(),
     }));
   };
 

--- a/pages/form/TravelMethod.jsx
+++ b/pages/form/TravelMethod.jsx
@@ -27,30 +27,13 @@ console.log(tranKey);
 export default function TravelMethod() {
   const { answers, setAnswers } = useForm();
 
+  //TODO: REMOVE TRANSPORTmODE STATE HOOKS AND ITS REFERENCES
   const [transportMode, setTransportMode] = useState(
     answers.mainTransportMode || []
-  );
-  const [status, setStatus] = useState(
-    new Array(travelMethods.length).fill(false)
   );
 
   const saveAnswers = () =>
     setAnswers((prev) => ({ ...prev, mainTransportMode: transportMode }));
-
-  // handle when method button clicked
-
-  const methodClickHandler = (eventText) => {
-    const ind = travelMethods.indexOf(eventText);
-
-    const copy = [...status];
-    copy[ind] = !copy[ind];
-    setStatus(copy);
-
-    let selected = transportMode;
-
-    selected = [...selected, eventText];
-    setTransportMode(selected);
-  };
 
   const router = useRouter();
 
@@ -120,16 +103,13 @@ export default function TravelMethod() {
         centerContent
         p="0px"
       >
-        <TravelMethodButtons
-          methodClickHandler={methodClickHandler}
-          status={status}
-        />
+        <TravelMethodButtons />
 
         {/* NEXT BUTTON  */}
 
         <Flex mb="30px" justify={["center", "end"]} width={["305px", "500px"]}>
           <ContinueButton
-            disabled={!status.includes(true)}
+            disabled={answers.travelMethods.length === 0}
             href="/form/ConfirmWFH"
             width={["305px", "105px"]}
             height={["60px", "54.37px"]}

--- a/pages/form/TravelMethod.jsx
+++ b/pages/form/TravelMethod.jsx
@@ -14,26 +14,8 @@ import { travelMethods } from "../../utils/constants";
 import Q4Cloud from "../../public/images/clouds/cloud-travelMethodSelection.svg";
 import { sendLogs } from "../../utils/sendLogs";
 
-// testing data object
-
-let answ = {
-  traveledWay: [{ Bus: [] }, { Car: [] }],
-};
-
-const tranKey = Object.keys(Object.assign({}, ...answ.traveledWay));
-console.log(tranKey);
-// Testing works for collection initial answered saved transport mode collected in tranKey
-
 export default function TravelMethod() {
-  const { answers, setAnswers } = useForm();
-
-  //TODO: REMOVE TRANSPORTmODE STATE HOOKS AND ITS REFERENCES
-  const [transportMode, setTransportMode] = useState(
-    answers.mainTransportMode || []
-  );
-
-  const saveAnswers = () =>
-    setAnswers((prev) => ({ ...prev, mainTransportMode: transportMode }));
+  const { answers, _ } = useForm();
 
   const router = useRouter();
 
@@ -47,7 +29,6 @@ export default function TravelMethod() {
       page: router.pathname,
       event: msg,
       ...answers,
-      mainTransportMode: transportMode,
       incentive: incentiveMsg(),
     };
   };
@@ -78,7 +59,6 @@ export default function TravelMethod() {
         <BackButton
           href={getBackHref(answers.workMode)}
           onClick={() => {
-            saveAnswers();
             sendLogs(logMessage("Back button clicked"));
           }}
         />
@@ -115,7 +95,6 @@ export default function TravelMethod() {
             height={["60px", "54.37px"]}
             justifySelf="right"
             onClick={() => {
-              saveAnswers();
               sendLogs(logMessage("Next button clicked"));
             }}
           >


### PR DESCRIPTION
## Overview of the Pull Request:
This PR will introduce the following changes:
- save responses for `TravelMethod` page (to `answers.travelMethods`)
- refactor `TravelMethodButtons` component:
  - handle component's state management within component itself
    - buttons' state stored in `travelMethodButtonStates` State hook, managed within component
    - define `handleTravelMethodButtonClick` method to deal with button click events and save responses to `answers.travelMethods`, and update `answers.carpoolPassengerCount`
  - create `updateCarpoolPassengerCount()` method to update `answers.carpoolPassengerCount` according to the following criterias:
    - if `Carpool` is selected, set `carpoolPassengerCount` to 1
    - if `Carpool` already selected, do not reinitialise `carpoolPassengerCount` (keep current value)
    - if `Carpool` is unselected, set `carpoolPassengerCount` to 0
- refactor and tidy up `TravelMethod` page:
  - remove `TravelMethodButtons` component's state hook declaration from this page
  - remove `TravelMethodButtons` component's button click handler declaration from this page
  - remove test code
  - remove `transportMode` state hook
  - deprecate usage of `answers.mainTransportMode` to save travel method responses (use `answers.travelMethods` instead)
  - remove `saveAnswers` method, now that responses are saved via `TravelMethodButtons` component

## How Has This Been Tested?
Reviewers should verify that the following features for `TravelMethod` page work as expected in the preview deployment:
- [x] existing functions of `TravelMethod` still work as expected (eg, button selections, next button works, carpool count component appears when 'Carpool' button selected, etc)
- [x] Travel Method responses are saved
  - [x] respondents should be able to review their travel method responses by returning to `TravelMethods` page (their selected responses should be unchanged) 
- [ ] correctness of log messages in logflare
  - [x] respondents' `Travel Method` selection(s) should appear in `TravelMethods` field in log message
  - [x] respondents' changes to `Travel Method` selection(s) should also be logged
- [ ] correctness of `carpoolPassengerCount` value (check in logflare log messages)
  - [x] when respondent selects `Carpool` as a travel method, `carpoolPassengerCount` value should be set to 1
  - [x] when respondent deselects `Carpool` as a travel method, `carpoolPassengerCount` value should be reset to 0
  - [x] respondents should be able to review their carpool count response by returning to `TravelMethods` page (their carpool count response should be unchanged) 

## Things regarding `TravelMethod` page that HAS NOT been addressed in this PR
- The logic for putting a constraint on the number of travel methods a respondent can select (and disabling the other travel methods) has not been implemented in this PR. This will be addressed in a separate PR
- There are still some open questions regarding how that logic is applied against the hybrid work flow, that @hqtan needs to discuss with the team.
- the colour of the button when a mouse hovers over it, is the same as the colour of a selected button. This should be discussed with team. 


## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
