### PR TITLE
add `Department` page

### DIFF
--- a/pages/form/Department.jsx
+++ b/pages/form/Department.jsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import {
+  Heading,
+  FormControl,
+  FormHelperText,
+  Box,
+  Text,
+  Select,
+  Flex,
+} from "@chakra-ui/react";
+import Layout from "../../components/Layout/Layout";
+import useForm from "../../components/FormProvider";
+import { departments } from "../../utils/constants";
+import {
+  BackButton,
+  ContinueButton,
+  SubmitButton,
+} from "../../components/LinkButton/LinkButton";
+import capitalize from "../../utils/capitalize";
+import Q5Progress from "../../public/images/progress-bar/q5-progress-dots.svg";
+import Q5Cloud from "../../public/images/clouds/cloud-q5.svg";
+import { useRouter } from "next/router";
+import { sendLogs } from "../../utils/sendLogs";
+import { sendFormResponse } from "../../utils/dbApi";
+
+export default function Department() {
+  const { answers, setAnswers } = useForm();
+  const [department, setDepartment] = useState(answers.department);
+
+  const saveAnswers = () =>
+    setAnswers((prev) => ({ ...prev, department: department }));
+
+  const router = useRouter();
+
+  const logMessage = (msg) => {
+    let incentiveMsg = () => {
+      if (!!answers.incentive) {
+        return "<filled>";
+      } else return "<empty>";
+    };
+    return {
+      page: router.pathname,
+      event: msg,
+      ...answers,
+      department: department,
+      incentive: incentiveMsg(),
+    };
+  };
+
+  return (
+    <Layout
+      isText={true}
+      Progress={Q5Progress}
+      maxContainerWidth="container.md"
+    >
+      <Box pos="absolute" top={["2", "5"]} left={["2", "10"]}>
+        <BackButton
+          href="/form/Question4"
+          onClick={() => {
+            saveAnswers();
+            sendLogs(logMessage("Back button clicked"));
+          }}
+        />
+      </Box>
+      <Q5Cloud />
+
+      <Heading>Which department do you work for?</Heading>
+
+      <Flex flexDirection={["column", "row"]} w="100%" mt={7}>
+        <Box width={["100", "50%"]} mt={5}>
+          <Text textAlign={["center", "left"]} fontSize="18px">
+            This helps us to provide more transparency to support the outcome of
+            this initiative.
+          </Text>
+        </Box>
+
+        <Box width={["100%"]} flex={1} mt={[12, 5]} ms={[0, 5]}>
+          <FormControl isRequired>
+            <Select
+              fontWeight="bold"
+              width="100%"
+              height="55px"
+              placeholder="Please select"
+              onChange={(e) => setDepartment(e.target.value)}
+              defaultValue={answers.department}
+              id="selector"
+            >
+              {departments.map((department) => (
+                <option key={department} value={department}>
+                  {capitalize(department)}
+                </option>
+              ))}
+            </Select>
+            <FormHelperText id="selectorHelper">*Required</FormHelperText>
+          </FormControl>
+          <SubmitButton
+            disabled={!department}
+            topMargin={4}
+            href="/form/Thankyou"
+            onClick={() =>
+              setAnswers((prev) => {
+                const response = { ...prev, department: department };
+                sendLogs(logMessage("Submit button clicked"));
+                sendFormResponse(response);
+                return response;
+              })
+            }
+            width={["100%", "90%"]}
+          />
+        </Box>
+      </Flex>
+    </Layout>
+  );
+}

--- a/pages/form/Department.jsx
+++ b/pages/form/Department.jsx
@@ -55,7 +55,7 @@ export default function Department() {
     >
       <Box pos="absolute" top={["2", "5"]} left={["2", "10"]}>
         <BackButton
-          href="/form/Question4"
+          href="/form/Suggestions"
           onClick={() => {
             saveAnswers();
             sendLogs(logMessage("Back button clicked"));


### PR DESCRIPTION
## Overview of the Pull Request:
Adding the **final** page to survey!
The `Department` page is a copy of `pages/form/Question5.jsx`, with slight modifications.
It collects the respondents department info that they work for.

## How Has This Been Tested?
Reviewers should verify the following in the preview deployment:
- [x] the `Department` page is displayed when user clicks 'Next' on `Suggestions` page
- [x] the `Thankyou` page is displayed when user clicks 'Next' on `Department` page
- [x] the `Suggestions` page is displayed when user clicks `Back` on `Department` page
- [x] the response given on `Department` page is saved correctly (see logflare log message)
- [x] the `Submit` button is disable until user makes a response

## Out of Scope
- checking that the responses are sent to Google sheets when user clicks 'Submit'. This needs more work, and will be addressed on a separate PR 

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ]~ Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
