### PR TITLE
wrap text for ride share button

### DIFF
--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -28,6 +28,10 @@ export default function TravelMethodButton({ name, onClick, isActive, ind }) {
             fontWeight="400"
             lineHeight="19px"
             letterSpacing="0.022em"
+            style={{
+              whiteSpace: "normal",
+              wordWrap: "break-word",
+            }}
           >
             {name}
           </Text>


### PR DESCRIPTION
## Overview of the Pull Request:
- This PR made a small change in fixing the `taxi/ride share` text on travelMethod page to be wrapped on mobile version. 

## link to Trello card or Github issue
https://trello.com/c/z50v3GrA/297-dev-travel-method-selection-page

## How Has This Been Tested?
- Tested locally and viewed to verify the changes on mobile version. 
- You can view the old version and the preview this changes to see the difference.


## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x ] Is your pull request up-to-date with `main` branch?
- [x ] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x ] Have you written instructions on how to test that your changes work as expected?
- [ x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
