### PR TITLE
[WIP] Add travel method selection limit

### DIFF
--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -1,7 +1,13 @@
 import { Box, Button, Flex, Icon, Text } from "@chakra-ui/react";
 import { transportIcon } from "../../utils/constants";
 
-export default function TravelMethodButton({ name, onClick, isActive, isDisabled, ind }) {
+export default function TravelMethodButton({
+  name,
+  onClick,
+  isActive,
+  isDisabled,
+  ind,
+}) {
   return (
     <Button
       fontSize="16px"
@@ -23,7 +29,7 @@ export default function TravelMethodButton({ name, onClick, isActive, isDisabled
           cursor: "not-allowed",
           bg: "#D0D9DF",
         },
-        color: "white"
+        color: "white",
       }}
       disabled={isDisabled}
     >

--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -1,7 +1,7 @@
 import { Box, Button, Flex, Icon, Text } from "@chakra-ui/react";
 import { transportIcon } from "../../utils/constants";
 
-export default function TravelMethodButton({ name, onClick, isActive, ind }) {
+export default function TravelMethodButton({ name, onClick, isActive, isDisabled, ind }) {
   return (
     <Button
       fontSize="16px"
@@ -17,6 +17,15 @@ export default function TravelMethodButton({ name, onClick, isActive, ind }) {
         color: "#fff",
       }}
       colorScheme="blue"
+      _disabled={{
+        bg: "#D0D9DF",
+        _hover: {
+          cursor: "not-allowed",
+          bg: "#D0D9DF",
+        },
+        color: "white"
+      }}
+      disabled={isDisabled}
     >
       <Flex justify="center" align="center" direction="column">
         <Icon as={transportIcon[ind]} fontSize={"20px"} />

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -16,22 +16,20 @@ const TravelMethodButtons = () => {
     switch (workArrangement) {
       case "hybrid":
       case "onsite":
-        return workOnSiteDays
+        return workOnSiteDays;
       case "wfh":
         return wfhDays;
       default:
         return 0;
     }
-  }
+  };
 
-  const updatedTravelMethods = (
-    travelMethods = answers.travelMethods
-  ) => {
+  const updatedTravelMethods = (travelMethods = answers.travelMethods) => {
     if (travelMethods.length > workDays()) {
       let diff = workDays() - travelMethods.length;
-      return travelMethods.slice(0,diff);
+      return travelMethods.slice(0, diff);
     } else return travelMethods;
-  }
+  };
 
   const [travelMethodButtonStates, setTravelMethodButtonStates] = useState(
     travelMethods.map((tm, idx) => {
@@ -40,13 +38,12 @@ const TravelMethodButtons = () => {
       // * travel method selection limit has been reached
       let updateDisabledState = () => {
         if (
-          !updatedTravelMethods().includes(tm)
-          &&
-          (updatedTravelMethods().length >= workDays())
+          !updatedTravelMethods().includes(tm) &&
+          updatedTravelMethods().length >= workDays()
         ) {
           return true;
         } else return false;
-      }
+      };
 
       return {
         id: idx,
@@ -64,13 +61,13 @@ const TravelMethodButtons = () => {
       } else return { ...item };
     });
 
-    const updatedNumTravelMethod = updatedState
-      .filter((tm) => tm.isSelected)
-      .length;
+    const updatedNumTravelMethod = updatedState.filter(
+      (tm) => tm.isSelected
+    ).length;
 
     // disable buttons if travel method selection limit reached...
     updatedState = updatedState.map((item) => {
-      if (!item.isSelected && (updatedNumTravelMethod >= workDays())) {
+      if (!item.isSelected && updatedNumTravelMethod >= workDays()) {
         return { ...item, isDisabled: true };
       } else return { ...item, isDisabled: false };
     });

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -8,6 +8,22 @@ import useForm from "../../components/FormProvider";
 const TravelMethodButtons = () => {
   const { answers, setAnswers } = useForm();
 
+  const workDays = (
+    workArrangement = answers.workMode,
+    workOnSiteDays = answers.onsiteDays.length,
+    wfhDays = answers.wfhDays.length
+  ) => {
+    switch (workArrangement) {
+      case "hybrid":
+      case "onsite":
+        return workOnSiteDays
+      case "wfh":
+        return wfhDays;
+      default:
+        return 0;
+    }
+  }
+
   const [travelMethodButtonStates, setTravelMethodButtonStates] = useState(
     travelMethods.map((tm, idx) => {
       // make sure to disable button ONLY if:
@@ -17,7 +33,7 @@ const TravelMethodButtons = () => {
         if (
           !answers.travelMethods.includes(tm)
           &&
-          (answers.travelMethods.length >= answers.onsiteDays.length)
+          (answers.travelMethods.length >= workDays())
         ) {
           return true;
         } else return false;
@@ -45,7 +61,7 @@ const TravelMethodButtons = () => {
 
     // disable buttons if travel method selection limit reached...
     updatedState = updatedState.map((item) => {
-      if (!item.isSelected && (updatedNumTravelMethod >= answers.onsiteDays.length)) {
+      if (!item.isSelected && (updatedNumTravelMethod >= workDays())) {
         return { ...item, isDisabled: true };
       } else return { ...item, isDisabled: false };
     });

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -10,11 +10,24 @@ const TravelMethodButtons = () => {
 
   const [travelMethodButtonStates, setTravelMethodButtonStates] = useState(
     travelMethods.map((tm, idx) => {
+      // make sure to disable button ONLY if:
+      // * button not already selected, and
+      // * travel method selection limit has been reached
+      let updateDisabledState = () => {
+        if (
+          !answers.travelMethods.includes(tm)
+          &&
+          (answers.travelMethods.length >= answers.onsiteDays.length)
+        ) {
+          return true;
+        } else return false;
+      }
+
       return {
         id: idx,
         travelMethod: tm,
         isSelected: answers.travelMethods.includes(tm),
-        isDisabled: false,
+        isDisabled: updateDisabledState(),
       };
     })
   );
@@ -24,6 +37,17 @@ const TravelMethodButtons = () => {
       if (item.travelMethod === buttonName) {
         return { ...item, isSelected: !item.isSelected };
       } else return { ...item };
+    });
+
+    const updatedNumTravelMethod = updatedState
+      .filter((tm) => tm.isSelected)
+      .length;
+
+    // disable buttons if travel method selection limit reached...
+    updatedState = updatedState.map((item) => {
+      if (!item.isSelected && (updatedNumTravelMethod >= answers.onsiteDays.length)) {
+        return { ...item, isDisabled: true };
+      } else return { ...item, isDisabled: false };
     });
 
     let selectedTravelMethods = updatedState
@@ -66,6 +90,7 @@ const TravelMethodButtons = () => {
             <TravelMethodButton
               name={item.travelMethod}
               isActive={item.isSelected}
+              isDisabled={item.isDisabled}
               onClick={handleTravelMethodButtonClick}
               ind={item.id}
             />

--- a/components/TravelMethodButtons/TravelMethodButtons.jsx
+++ b/components/TravelMethodButtons/TravelMethodButtons.jsx
@@ -24,6 +24,15 @@ const TravelMethodButtons = () => {
     }
   }
 
+  const updatedTravelMethods = (
+    travelMethods = answers.travelMethods
+  ) => {
+    if (travelMethods.length > workDays()) {
+      let diff = workDays() - travelMethods.length;
+      return travelMethods.slice(0,diff);
+    } else return travelMethods;
+  }
+
   const [travelMethodButtonStates, setTravelMethodButtonStates] = useState(
     travelMethods.map((tm, idx) => {
       // make sure to disable button ONLY if:
@@ -31,9 +40,9 @@ const TravelMethodButtons = () => {
       // * travel method selection limit has been reached
       let updateDisabledState = () => {
         if (
-          !answers.travelMethods.includes(tm)
+          !updatedTravelMethods().includes(tm)
           &&
-          (answers.travelMethods.length >= workDays())
+          (updatedTravelMethods().length >= workDays())
         ) {
           return true;
         } else return false;
@@ -42,7 +51,7 @@ const TravelMethodButtons = () => {
       return {
         id: idx,
         travelMethod: tm,
-        isSelected: answers.travelMethods.includes(tm),
+        isSelected: updatedTravelMethods().includes(tm),
         isDisabled: updateDisabledState(),
       };
     })
@@ -115,7 +124,7 @@ const TravelMethodButtons = () => {
       </SimpleGrid>
 
       {/* Carpool counter */}
-      {answers.travelMethods.includes("Carpool") && <CarpoolCounter />}
+      {updatedTravelMethods().includes("Carpool") && <CarpoolCounter />}
     </>
   );
 };


### PR DESCRIPTION
## Overview of the Pull Request:

This PR updates the 'Travel Method' survey question to place a limit on the number of travel methods a respondent can select:
- in the 'wfh' flow, that limit is set as the number of wfh days respondent selected in 'WorkFromHomeDays' page
- in the 'hybrid' and 'onsite' flow, that limit is set as the number of onsite days respondent selected in 'WorkOnSiteDays' page

this PR also addresses what happens to travel method selections in the scenario where respondent returns to 'WorkFromHomeDays' or 'WorkOnSiteDays' page to reduce the number of work days selected. 
In that scenario, the respondent's travel method selections will also be reduced accordingly to match the updated work days. 

## link to Trello card or Github issue
https://trello.com/c/z50v3GrA

## How Has This Been Tested?
- confirm that respondent can only select (at most) the same number of travel methods as the number of work days he/she selected
- confirm that, if respondent returns to 'WorkFromHomeDays' or 'WorkOnSiteDays' page to reduce the number of work days selected, the respondent's travel method selections will also be reduced accordingly to stay within travel selection limit.

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
