### PR TITLE
Work days layout change for mobile

### DIFF
--- a/components/TravelDayButtons/TravelDayButton.jsx
+++ b/components/TravelDayButtons/TravelDayButton.jsx
@@ -2,22 +2,28 @@ import { Button, Text } from "@chakra-ui/react";
 import useForm from "../../components/FormProvider";
 import { travelMethods } from "../../utils/constants";
 
-export default function TravelDayButton ({ label, travelMethod }) {
+export default function TravelDayButton({ label, travelMethod }) {
   const { answers, setAnswers } = useForm();
 
-  console.log(`answers.travelMethodByDay: ${JSON.stringify(answers.travelMethodByDay, null, " ")}`);
+  console.log(
+    `answers.travelMethodByDay: ${JSON.stringify(
+      answers.travelMethodByDay,
+      null,
+      " "
+    )}`
+  );
 
   const isSelected = () => {
-    if ( travelMethods.includes(answers.travelMethodByDay[label]) ) {
+    if (travelMethods.includes(answers.travelMethodByDay[label])) {
       return true;
     } else return false;
   };
 
   const isDisabled = () => {
     //does this day have a travel method?
-    if ( travelMethods.includes(answers.travelMethodByDay[label]) ) {
+    if (travelMethods.includes(answers.travelMethodByDay[label])) {
       //is this day already taken by a different travel method?
-      if ( answers.travelMethodByDay[label] === travelMethod ) {
+      if (answers.travelMethodByDay[label] === travelMethod) {
         return false;
       } else return true;
     } else return false;
@@ -29,7 +35,7 @@ export default function TravelDayButton ({ label, travelMethod }) {
 
     // if button already selected, unset travel method for day on click
     if (isSelected()) updatedTravelDays[day] = "";
-    else updatedTravelDays[day] = travelMethod;  // set travelMethod for day
+    else updatedTravelDays[day] = travelMethod; // set travelMethod for day
 
     setAnswers((prev) => ({
       ...prev,
@@ -53,13 +59,18 @@ export default function TravelDayButton ({ label, travelMethod }) {
           cursor: "not-allowed",
           bg: "#D0D9DF",
         },
-        color: "white"
+        color: "white",
       }}
       disabled={isDisabled()}
     >
-      <Text fontSize="18px"  fontFamily="Public Sans"
+      <Text
+        fontSize="18px"
+        fontFamily="Public Sans"
         fontWeight="500"
-        lineHeight="28px">{label}</Text>
+        lineHeight="28px"
+      >
+        {label}
+      </Text>
     </Button>
-  )
-};
+  );
+}

--- a/components/TravelDayButtons/TravelDayButton.jsx
+++ b/components/TravelDayButtons/TravelDayButton.jsx
@@ -41,7 +41,7 @@ export default function TravelDayButton ({ label, travelMethod }) {
 
   return (
     <Button
-      w={["305px", "128.75px"]}
+      w={["90%", "128.75px"]}
       h="55px"
       borderRadius="8px"
       colorScheme="blue"

--- a/components/TravelDayButtons/TravelDayButtonsContainer.jsx
+++ b/components/TravelDayButtons/TravelDayButtonsContainer.jsx
@@ -15,7 +15,7 @@ export default function TravelDayButtonsContainer({ title, methodIconIndex }) {
   return (
     <Box
       direction="column"
-      align="space-between"
+      align={["center", "space-between"]}
       borderWidth="2px"
       borderRadius="lg"
       px="3%"
@@ -23,23 +23,24 @@ export default function TravelDayButtonsContainer({ title, methodIconIndex }) {
       mb="5%"
     >
       <Flex>
-        <Flex align="flex-start">
-          <Icon
-            justifySelf="end"
-            w={7}
-            h={7}
-            as={transportIcon[methodIconIndex]}
-          />
-          <Spacer />
-          <Flex direction="column" align="left" pl="15px">
+        <Flex align={["center", "flex-start"]} direction="column">
+          <Flex>
+            <Icon
+              justifySelf="end"
+              w={7}
+              h={7}
+              as={transportIcon[methodIconIndex]}
+              mx={3}
+            />
+            <Spacer />
             <Text color="#044B7F" fontWeight="500" fontSize="24px">
               {title}
             </Text>
-            <Flex>
-              <Text fontWeight="500" fontSize="22px">
-                Select the days you travel to work by {title}.
-              </Text>
-            </Flex>
+          </Flex>
+          <Flex pl="15px" ml={[0, 9]}>
+            <Text fontWeight="500" fontSize="22px" textAlign={["center", "left"]}>
+              Select the days you travel to work by {title}.
+            </Text>
           </Flex>
         </Flex>
         <Spacer />

--- a/components/TravelDayButtons/TravelDayButtonsContainer.jsx
+++ b/components/TravelDayButtons/TravelDayButtonsContainer.jsx
@@ -38,7 +38,11 @@ export default function TravelDayButtonsContainer({ title, methodIconIndex }) {
             </Text>
           </Flex>
           <Flex pl="15px" ml={[0, 9]}>
-            <Text fontWeight="500" fontSize="22px" textAlign={["center", "left"]}>
+            <Text
+              fontWeight="500"
+              fontSize="22px"
+              textAlign={["center", "left"]}
+            >
               Select the days you travel to work by {title}.
             </Text>
           </Flex>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -49,7 +49,7 @@ export default function TravelDays() {
   };
 
   return (
-    <Layout isText={true} Progress={Q5Progress}>
+    <Layout isText={true} Progress={Q5Progress} maxContainerWidth={"750"}>
       <Box pos="absolute" top={["2", "5"]} left={["2", "10"]}>
         <BackButton
           href={"/form/TravelMethod"}
@@ -58,7 +58,7 @@ export default function TravelDays() {
           }}
         />
       </Box>
-      <Box minW="720px">
+      <Box>
         <Flex justify="center" direction="column">
           <Q3Cloud />
           <Heading mt={10} mb={10}>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -68,7 +68,7 @@ export default function TravelDays() {
         {answers.travelMethods.map((tm) => (
           <Box key={tm}>{travelComponent(tm)}</Box>
         ))}
-        <Flex justify="end">
+        <Flex justify={["center", "end"]}>
           <LinkButton
             disabled={
               //check if any response has been given;
@@ -80,7 +80,7 @@ export default function TravelDays() {
             }
             mt="10px"
             href={"/form/Distance"}
-            width="105px"
+            width={["100%", "105px"]}
             H="55px"
             justifySelf="right"
             onClick={() => saveDataAndShowLog("Next button clicked")}

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -62,8 +62,7 @@ export default function TravelDays() {
         <Flex justify="center" direction="column">
           <Q3Cloud />
           <Heading mt={10} mb={10}>
-            Please select the days you travel to work using the selected travel
-            methods
+            Please select the days for your travel
           </Heading>
         </Flex>
         {answers.travelMethods.map((tm) => (


### PR DESCRIPTION
## Overview of the Pull Request:
Working on responsiveness of the page:
* Remove minW and replace with maxContainerWidth;
* Icon and title of each card are center aligned on mobile;
* Link button is 100% width on mobile;
* Day buttons have adjustable width based on the container on re-sizing;

## link to Trello card or Github issue
Result below
![image](https://user-images.githubusercontent.com/88268603/166919051-47ee9aa8-5428-4d3f-98cd-1d7ac0dd5dfa.png)

## How Has This Been Tested?
* Open the page in desktop mode;
* Resize the page;
* Use toggle device toolbar to check mobile version.

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
