### PR TITLE
remove custom settings for disabled buttons to improve color contrast between button background and text

### DIFF
--- a/components/DaysOfTheWeek/DayOfTheWeekButton.jsx
+++ b/components/DaysOfTheWeek/DayOfTheWeekButton.jsx
@@ -14,14 +14,6 @@ export default function DaysOfTheWeekButton ({ label, onClick, isActive, disable
       colorScheme="blue"
       variant={isActive ? "solid" : "outline"}
       onClick={(e) => onClick(e.target.innerText)}
-      _disabled={{
-        bg: "#D0D9DF",
-        _hover: {
-          cursor: "not-allowed",
-          bg: "#D0D9DF",
-        },
-        color: "white"
-      }}
       disabled={disabled}
     >
       <Text fontSize="18px"  fontFamily="Public Sans"

--- a/components/LinkButton/LinkButton.jsx
+++ b/components/LinkButton/LinkButton.jsx
@@ -23,13 +23,6 @@ export default function LinkButton({
         _hover={{
           bg: "var(--chakra-colors-blue-500)",
         }}
-        _disabled={{
-          bg: "#D0D9DF",
-          _hover: {
-            cursor: "not-allowed",
-            bg: "#D0D9DF",
-          },
-        }}
         color={color || "#fff"}
         onClick={onClick}
         disabled={disabled}

--- a/components/TravelDayButtons/TravelDayButton.jsx
+++ b/components/TravelDayButtons/TravelDayButton.jsx
@@ -53,14 +53,6 @@ export default function TravelDayButton({ label, travelMethod }) {
       colorScheme="blue"
       variant={isSelected() ? "solid" : "outline"}
       onClick={handleClick}
-      _disabled={{
-        bg: "#D0D9DF",
-        _hover: {
-          cursor: "not-allowed",
-          bg: "#D0D9DF",
-        },
-        color: "white",
-      }}
       disabled={isDisabled()}
     >
       <Text

--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -19,6 +19,13 @@ export default function TravelMethodButton({
       variant={isActive ? "solid" : "outline"}
       _active={{ border: "solid" }}
       colorScheme="blue"
+      _disabled={{
+        bg: "#ACCCEB",
+        _hover: {
+          color: "#ACCCEB",
+        },
+        color: "white",
+      }}
       disabled={isDisabled}
     >
       <Flex justify="center" align="center" direction="column">

--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -19,14 +19,6 @@ export default function TravelMethodButton({
       variant={isActive ? "solid" : "outline"}
       _active={{ border: "solid" }}
       colorScheme="blue"
-      _disabled={{
-        bg: "#D0D9DF",
-        _hover: {
-          cursor: "not-allowed",
-          bg: "#D0D9DF",
-        },
-        color: "white",
-      }}
       disabled={isDisabled}
     >
       <Flex justify="center" align="center" direction="column">


### PR DESCRIPTION
## Overview of the Pull Request:
- remove custom colorscheme and behaviour for disabled buttons
  (`DayOfTheWeekButton`s, `LinkButton`s, `TravelDayButton`s and
  `TravelMethodButton`)

## link to Trello card or Github issue

## How Has This Been Tested?
Reviewers to confirm that:
- the color contrast for disabled `DayOfTheWeekButton` and `TravelDayButton` matches screenshot below:
  ![image](https://user-images.githubusercontent.com/4408259/167777197-282b976c-b7ce-41aa-9b87-7694e4474bca.png)
- the color contrast for disabled `TravelMethodButton` matches screenshot below
  ![image](https://user-images.githubusercontent.com/4408259/167777378-7922b822-6c0c-4bce-b905-c1fee7e3342b.png)

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
