### PR TITLE
Travel days alert - add an option for the case when not all days are selected

### DIFF
--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -146,7 +146,7 @@ export default function TravelDays() {
           </Flex>
           <AlertDescription>
             {!checkIfNotAllTravelMethodsSelected
-              ? "Please select a travel method for each work day."
+              ? `Please select a travel method for ${(daysNotYetSelected().map(day => ` ${day}`))}.`
               : "Please select at least one work day for each travel method."}
           </AlertDescription>
         </Alert>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -83,6 +83,17 @@ export default function TravelDays() {
     })
     .every((tm) => answers.travelMethods.includes(tm));
 
+  const daysNotYetSelected = () => {
+    const travelMethodsByDays = answers.travelMethodByDay;
+    let daysLeft = [];
+    workDays().map(key => {
+      if (Object.keys(travelMethodsByDays).includes(key)&&!travelMethodsByDays[key]) {
+        daysLeft.push(key);
+      }
+    })
+    return daysLeft;
+  }
+
   const travelComponent = (tm) => {
     const ind = travelMethods.indexOf(tm);
 

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -134,7 +134,9 @@ export default function TravelDays() {
             <AlertTitle>Incomplete selection</AlertTitle>
           </Flex>
           <AlertDescription>
-            {(!checkIfNotAllTravelMethodsSelected)?"Please select a travel method for each work day.":"Please select at least one work day for each travel method."}
+            {!checkIfNotAllTravelMethodsSelected
+              ? "Please select a travel method for each work day."
+              : "Please select at least one work day for each travel method."}
           </AlertDescription>
         </Alert>
         <Flex justify={["center", "end"]}>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -134,7 +134,7 @@ export default function TravelDays() {
             <AlertTitle>Incomplete selection</AlertTitle>
           </Flex>
           <AlertDescription>
-            Please select at least one work day for each travel method.
+            {(!checkIfNotAllTravelMethodsSelected)?"Please select a travel method for each work day.":"Please select at least one work day for each travel method."}
           </AlertDescription>
         </Alert>
         <Flex justify={["center", "end"]}>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -86,13 +86,16 @@ export default function TravelDays() {
   const daysNotYetSelected = () => {
     const travelMethodsByDays = answers.travelMethodByDay;
     let daysLeft = [];
-    workDays().map(key => {
-      if (Object.keys(travelMethodsByDays).includes(key)&&!travelMethodsByDays[key]) {
+    workDays().map((key) => {
+      if (
+        Object.keys(travelMethodsByDays).includes(key) &&
+        !travelMethodsByDays[key]
+      ) {
         daysLeft.push(key);
       }
-    })
+    });
     return daysLeft;
-  }
+  };
 
   const travelComponent = (tm) => {
     const ind = travelMethods.indexOf(tm);
@@ -127,7 +130,7 @@ export default function TravelDays() {
           ))}
         </Flex>
         <Alert
-          status={!checkIfNotAllTravelMethodsSelected?"warning":"success"}
+          status={!checkIfNotAllTravelMethodsSelected ? "warning" : "success"}
           display={
             ![
               checkIfNotAnySelected,
@@ -146,7 +149,9 @@ export default function TravelDays() {
           </Flex>
           <AlertDescription>
             {!checkIfNotAllTravelMethodsSelected
-              ? `Please select a travel method for ${(daysNotYetSelected().map(day => ` ${day}`))}.`
+              ? `Please select a travel method for ${daysNotYetSelected().map(
+                  (day) => ` ${day}`
+                )}.`
               : "Please select at least one work day for each travel method."}
           </AlertDescription>
         </Alert>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -149,9 +149,7 @@ export default function TravelDays() {
           </Flex>
           <AlertDescription>
             {!checkIfNotAllTravelMethodsSelected
-              ? `Please select a travel method for ${daysNotYetSelected().map(
-                  (day) => ` ${day}`
-                )}.`
+              ? `Please select a travel method for ${daysNotYetSelected().join(", ")}.`
               : "Please select at least one work day for each travel method."}
           </AlertDescription>
         </Alert>

--- a/pages/form/TravelDays.jsx
+++ b/pages/form/TravelDays.jsx
@@ -127,7 +127,7 @@ export default function TravelDays() {
           ))}
         </Flex>
         <Alert
-          status="success"
+          status={!checkIfNotAllTravelMethodsSelected?"warning":"success"}
           display={
             ![
               checkIfNotAnySelected,


### PR DESCRIPTION
## Overview of the Pull Request:
Change the alert message for travel days so it displays different content based on conditions (examples on screenshots):

**Title:** Incomplete selection (same for both versions.
**Body:**  "Please select a travel method for each work day."

## link to Trello card or Github issue
* Some travel methods don't have days: 
![image](https://user-images.githubusercontent.com/88268603/168465045-37469405-9e27-41f3-bcf7-d4a9258572bf.png)
* Not all days are selected:
![image](https://user-images.githubusercontent.com/88268603/168465082-f0152d0a-13b4-411d-bc3f-62ef69199c71.png)

## How Has This Been Tested?
1. Select more days than travel methods;
2. Select one day for each travel method leaving one or more days not selected. See if alert message has changed.

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
