### PR TITLE
trim any whitespaces around the text label in the daysOfTheWeek and TravelDayButtons button components

### DIFF
--- a/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
+++ b/components/DaysOfTheWeek/DaysOfTheWeekContainer.jsx
@@ -81,10 +81,11 @@ export default function DaysOfTheWeekContainer({
 
     // based on the day name from the value of each button, update the state if selected or unselected
     updatedData.map((item) => {
-      if (item.day === value) {
+      if (item.day === value.trim()) {
         item.isSelected = item.isSelected ? false : true;
       }
     });
+
     setDaysOfTheWeek(updatedData);
 
     // get answer to which days of the week user works

--- a/components/TravelDayButtons/TravelDayButton.jsx
+++ b/components/TravelDayButtons/TravelDayButton.jsx
@@ -30,7 +30,7 @@ export default function TravelDayButton({ label, travelMethod }) {
   };
 
   const handleClick = (e) => {
-    let day = e.target.innerText;
+    let day = e.target.innerText.trim();
     let updatedTravelDays = { ...answers.travelMethodByDay };
 
     // if button already selected, unset travel method for day on click


### PR DESCRIPTION
## Overview of the Pull Request:
This PR fixes a bug in iOS/Webkit browsers.

Problem: in Webkit browsers, the text labels in the DayOfWeek buttons and TravelDays buttons are surrounded by some whitespaces, causing Day-of-week matching issues in the backend logic.

Fix: use `.trim()` String method to remove any whitespaces from the text labels in the DayOfWeek buttons and TravelDays buttons

## ~link to Trello card or Github issue~

## How Has This Been Tested?
- verify that user can select Day of Week buttons in the following pages:
  - `WorkFromHomeDays` 
  - `WorkOnSiteDays` 
  - `TravelDays`
using a iphone browser (safari/chrome/firefox), and an android browser

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
