### PR TITLE
fix bug in iOS/WebKit browsers for TravelMethod page

### DIFF
--- a/components/TravelMethodButtons/TravelMethodButton.jsx
+++ b/components/TravelMethodButtons/TravelMethodButton.jsx
@@ -15,7 +15,7 @@ export default function TravelMethodButton({
       width={["91.67px", "150px"]}
       border="1px"
       p="0px"
-      onClick={(e) => onClick(e.target.innerText)}
+      onClick={(e) => onClick(e.currentTarget.textContent)}
       variant={isActive ? "solid" : "outline"}
       _active={{ border: "solid" }}
       colorScheme="blue"


### PR DESCRIPTION
## Overview of the Pull Request:
This PR fixes an bug that was observed in iOS/WebKit browsers, while browsing the `TravelMethods` page.

**Problem:** in Webkit browsers, the text labels in the Travel Method buttons could not be retrieved, causing issues in the backend logic.

**Fix:** use `e.currentTarget.textContent` to retrieve text in travel method buttons, instead of `e.target.innerText`


## How Has This Been Tested?
- verify that user can select Travel Method buttons in the `TravelMethod page on:
  - a iphone browser (safari/chrome/firefox), 
  - and an android browser
  - a desktop browser

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
