### PR TITLE
fix bug in iphone chrome browsers. shows `RangeError: timeZoneName must be "short" or "long"` error during form submission

### DIFF
--- a/utils/dbApi.js
+++ b/utils/dbApi.js
@@ -13,7 +13,7 @@ export const getTripCounts = async () => {
 };
 
 export const sendFormResponse = async (resp) => {
-  const datestring = new Date().toLocaleString("sv", { timeZoneName: "longOffset" });
+  const datestring = new Date().toLocaleString("sv", { timeZoneName: "short" });
   const params = {
     method: "POST",
     headers: {
@@ -23,13 +23,6 @@ export const sendFormResponse = async (resp) => {
   };
   const apiResponse = await fetch(`${hostname}/api/sheeter`, params);
   const text = await apiResponse.text();
-  // console.log(
-  //   `sendFormResponse : (status: ${apiResponse.status}) ${JSON.stringify(
-  //     text,
-  //     null,
-  //     "\t"
-  //   )}`
-  // );
 };
 
 export const getFormResponses = async () => {
@@ -41,12 +34,5 @@ export const getFormResponses = async () => {
   };
   const apiResponse = await fetch(`${hostname}/api/sheeter`, params);
   const text = await apiResponse.text();
-  // console.log(
-  //   `getFormResponses : (status: ${apiResponse.status}) ${JSON.stringify(
-  //     text,
-  //     null,
-  //     "\t"
-  //   )}`
-  // );
   return text;
 };


### PR DESCRIPTION
## Overview of the Pull Request:
This PR fixes an bug that was observed in Chrome browser on iphone 6s, during survey response submission (ie, when the 'Submit' button was clicked on the `Department` page).

**Problem**: in the Chrome browser on an iphone, the following error message was displayed when the 'Submit' button was clicked on the `Department` page:
```
RangeError: timeZoneName must be "short" or "long"
```

**Fix**: follow advise in error message - use `timeZoneName: "short"` for datestamp that is sent with form submission


## How Has This Been Tested?
- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce. 
- If necessary, please also list any relevant details for your test setup/configuration

## Pull Request Checklist:
- verify that `RangeError` error message does not appear during survey response submission (ie, when the 'Submit' button was clicked on the `Department` page). Should test form submission on as many browsers as feasible:
  - a iphone browser (safari/chrome/firefox), **especially on chrome**
  - and an android browser
  - a desktop browser

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] ~Have you included a link Trello card / Github issue and written sufficient description to help others review your work?~
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
