### PR TITLE
fix minor updates to silence the warning messages that appears on the console

### DIFF
--- a/components/ResultsPageComponents/DownloadResults/DownloadResults.jsx
+++ b/components/ResultsPageComponents/DownloadResults/DownloadResults.jsx
@@ -113,7 +113,7 @@ export default function DownloadResults() {
             fontFamily="Public Sans"
             fontWeight={200}
             fontSize="12px"
-            lineHight="14px"
+            lineHeight="14px"
           >
             Read how we have calculated and reported your emissions:
           </Text>

--- a/components/ResultsPageComponents/WorkArrangement/WorkArrangement.jsx
+++ b/components/ResultsPageComponents/WorkArrangement/WorkArrangement.jsx
@@ -45,7 +45,7 @@ export default function WorkArrangement({ workMode }) {
         <Flex direction={["column", "row"]} align={["center", "flex-end"]}>
           <Flex width="30%" direction="column" py="20px">
             <Flex justify="flex-end">
-              <Line maxWidth="150px" />
+              <Line maxwidth="150px" />
               <Flex direction="column">
                 <Text
                   fontWeight={500}
@@ -72,7 +72,7 @@ export default function WorkArrangement({ workMode }) {
           </Flex>
           <Flex width="30%" direction="column" py="20px">
             <Flex justify="flex-end">
-              <Line maxWidth="150px" />
+              <Line maxwidth="150px" />
               <Flex direction="column">
                 <Text
                   fontWeight={500}
@@ -104,7 +104,7 @@ export default function WorkArrangement({ workMode }) {
           </Flex>
           <Flex width="30%" direction="column" py="20px">
             <Flex justify="flex-end">
-              <Line maxWidth="150px" />
+              <Line maxwidth="150px" />
               <Flex direction="column">
                 <Text
                   fontWeight={500}


### PR DESCRIPTION
## Overview of the Pull Request:
This PR addresses the warning messages that appear on the console while viewing results page:
```
Warning: React does not recognize the `lineHight` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `linehight` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
...
Warning: React does not recognize the `maxWidth` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `maxwidth` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## link to Trello card or Github issue

## How Has This Been Tested?
test the changes locally, and confirm that the warning messages no longer appear when view the results page locally. 

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
