### PR TITLE
implement light and shaded backgrounds to the Results page

### DIFF
--- a/components/ResultsPageComponents/SharedComponents/ContentStyles.jsx
+++ b/components/ResultsPageComponents/SharedComponents/ContentStyles.jsx
@@ -1,0 +1,17 @@
+import { Box } from "@chakra-ui/react";
+
+const ResultContentSection = (props) => {
+  const { isShaded, children } = props;
+  return (
+    <Box
+      width="100vw"
+      py="inherit"
+      px="inherit"
+      bg={isShaded ? "#FAFAFA" : "inherit"}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export { ResultContentSection };

--- a/components/ResultsPageComponents/SharedComponents/ContentStyles.jsx
+++ b/components/ResultsPageComponents/SharedComponents/ContentStyles.jsx
@@ -4,7 +4,7 @@ const ResultContentSection = (props) => {
   const { isShaded, children } = props;
   return (
     <Box
-      width="100vw"
+      width="100%"
       py="inherit"
       px="inherit"
       bg={isShaded ? "#FAFAFA" : "inherit"}

--- a/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
+++ b/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
@@ -2,10 +2,8 @@ import { Box } from "@chakra-ui/react";
 
 export default function ResultContentSection({ isShaded, children }) {
   return (
-    <Box width="100%" my={5} px="68px" border="1px dashed blue">
-      <Box bg={isShaded ? "#FAFAFA" : "inherit"} border="1px dashed red">
-        {children}
-      </Box>
+    <Box width="100%" my={5} px="68px">
+      <Box bg={isShaded ? "#FAFAFA" : "inherit"}>{children}</Box>
     </Box>
   );
 }

--- a/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
+++ b/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
@@ -1,7 +1,6 @@
 import { Box } from "@chakra-ui/react";
 
-const ResultContentSection = (props) => {
-  const { isShaded, children } = props;
+export default function ResultContentSection({ isShaded, children }) {
   return (
     <Box
       width="100%"
@@ -12,6 +11,4 @@ const ResultContentSection = (props) => {
       {children}
     </Box>
   );
-};
-
-export { ResultContentSection };
+}

--- a/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
+++ b/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
@@ -2,7 +2,7 @@ import { Box } from "@chakra-ui/react";
 
 export default function ResultContentSection({ isShaded, children }) {
   return (
-    <Box width="100%" py="inherit" px="68px" border="1px dashed blue">
+    <Box width="100%" my={5} px="68px" border="1px dashed blue">
       <Box bg={isShaded ? "#FAFAFA" : "inherit"} border="1px dashed red">
         {children}
       </Box>

--- a/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
+++ b/components/ResultsPageComponents/SharedComponents/ResultContentSection.jsx
@@ -2,13 +2,10 @@ import { Box } from "@chakra-ui/react";
 
 export default function ResultContentSection({ isShaded, children }) {
   return (
-    <Box
-      width="100%"
-      py="inherit"
-      px="inherit"
-      bg={isShaded ? "#FAFAFA" : "inherit"}
-    >
-      {children}
+    <Box width="100%" py="inherit" px="68px" border="1px dashed blue">
+      <Box bg={isShaded ? "#FAFAFA" : "inherit"} border="1px dashed red">
+        {children}
+      </Box>
     </Box>
   );
 }

--- a/pages/results.js
+++ b/pages/results.js
@@ -46,15 +46,15 @@ export default function Results({ data }) {
           <SurveyIntro />
           <DownloadResults calculationLink="/howWeCalculate" />
         </Flex>
+        <SurveyOverview
+          startDate={data["survey-start-date"]}
+          endDate={data["survey-end-date"]}
+          totalResponses={data["total-number-responses"]}
+          totalDistance={data["total-distance"]}
+          totalEmissions={data["total-co2-emissions-tonnes"]}
+          totalTripCount={data["total-trip-count"]}
+        />
       </ResultContentSection>
-      <SurveyOverview
-        startDate={data["survey-start-date"]}
-        endDate={data["survey-end-date"]}
-        totalResponses={data["total-number-responses"]}
-        totalDistance={data["total-distance"]}
-        totalEmissions={data["total-co2-emissions-tonnes"]}
-        totalTripCount={data["total-trip-count"]}
-      />
       <ResultContentSection isShaded={true}>
         <TopThree
           topThree={data["TopThreeData"]}

--- a/pages/results.js
+++ b/pages/results.js
@@ -31,21 +31,22 @@ export async function getStaticProps() {
 export default function Results({ data }) {
   const { answers } = useForm();
   const { km, mainTransportMode, department, incentive } = answers;
-  console.log(data.dataAboutTrips);
   return (
     <Layout isText={true} maxContainerWidth="100%">
-      <Flex
-        px={["5px", "50px"]}
-        width="100%"
-        gap={["40px", "90px"]}
-        wrap="wrap"
-        direction={["column", "row"]}
-        justify="center"
-        align={["center", "flex-start"]}
-      >
-        <SurveyIntro />
-        <DownloadResults calculationLink="/howWeCalculate" />
-      </Flex>
+      <ResultContentSection isShaded={false}>
+        <Flex
+          px={["5px", "50px"]}
+          width="100%"
+          gap={["40px", "90px"]}
+          wrap="wrap"
+          direction={["column", "row"]}
+          justify="center"
+          align={["center", "flex-start"]}
+        >
+          <SurveyIntro />
+          <DownloadResults calculationLink="/howWeCalculate" />
+        </Flex>
+      </ResultContentSection>
       <SurveyOverview
         startDate={data["survey-start-date"]}
         endDate={data["survey-end-date"]}

--- a/pages/results.js
+++ b/pages/results.js
@@ -1,7 +1,10 @@
-import { Flex, Img, Text } from "@chakra-ui/react";
+import path from "path";
+import { Flex, Img } from "@chakra-ui/react";
 import React from "react";
 import useForm from "../components/FormProvider";
 import Layout from "../components/Layout/Layout";
+import fsPromises from "fs/promises";
+
 import DownloadResults from "../components/ResultsPageComponents/DownloadResults/DownloadResults";
 import SurveyOverview from "../components/ResultsPageComponents/SurveyOverview/SurveyOverview";
 import SurveyIntro from "../components/ResultsPageComponents/SurveyIntro/SurveyIntro";
@@ -11,9 +14,7 @@ import DistanceTravelledMode from "../components/ResultsPageComponents/DistanceT
 import WorkArrangement from "../components/ResultsPageComponents/WorkArrangement/WorkArrangement";
 import CommuteDays from "../components/ResultsPageComponents/CommuteDays/CommuteDays";
 import CommuteDistanceDistribution from "../components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistribution";
-import fsPromises from "fs/promises";
-import path from "path";
-import { ResultContentSection } from "../components/ResultsPageComponents/SharedComponents/ContentStyles";
+import ResultContentSection from "../components/ResultsPageComponents/SharedComponents/ResultContentSection";
 
 export async function getStaticProps() {
   const filePath = path.join(process.cwd(), "data/2022-results.json");

--- a/pages/results.js
+++ b/pages/results.js
@@ -13,6 +13,7 @@ import CommuteDays from "../components/ResultsPageComponents/CommuteDays/Commute
 import CommuteDistanceDistribution from "../components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistribution";
 import fsPromises from "fs/promises";
 import path from "path";
+import { ResultContentSection } from "../components/ResultsPageComponents/SharedComponents/ContentStyles";
 
 export async function getStaticProps() {
   const filePath = path.join(process.cwd(), "data/2022-results.json");
@@ -52,21 +53,24 @@ export default function Results({ data }) {
         totalEmissions={data["total-co2-emissions-tonnes"]}
         totalTripCount={data["total-trip-count"]}
       />
+      <ResultContentSection isShaded={true}>
+        <TopThree
+          topThree={data["TopThreeData"]}
+          totalDistance={data["total-distance"]}
+          totalTripCount={data["total-trip-count"]}
+          totalEmissions={data["total-co2-emissions-tonnes"]}
+        />
 
-      <TopThree
-        topThree={data["TopThreeData"]}
-        totalDistance={data["total-distance"]}
-        totalTripCount={data["total-trip-count"]}
-        totalEmissions={data["total-co2-emissions-tonnes"]}
-      />
-
-      <TripCountAndTravelMethods dataAboutTrips={data["dataAboutTrips"]} />
-      <WorkArrangement workMode={data["work-mode"]} />
-      <CommuteDays data={data} />
-      <CommuteDistanceDistribution data={data} />
-      <DistanceTravelledMode
-        data={data["distance-travelled-by-mode"]}
-      />        
+        <TripCountAndTravelMethods dataAboutTrips={data["dataAboutTrips"]} />
+      </ResultContentSection>
+      <ResultContentSection isShaded={false}>
+        <WorkArrangement workMode={data["work-mode"]} />
+        <CommuteDays data={data} />
+      </ResultContentSection>
+      <ResultContentSection isShaded={true}>
+        <CommuteDistanceDistribution data={data} />
+        <DistanceTravelledMode data={data["distance-travelled-by-mode"]} />
+      </ResultContentSection>
       <Flex
         border="2px solid red"
         width="100%"


### PR DESCRIPTION
## Overview of the Pull Request:
Implemented light and dark backgrounds for the "Results" page

Designers have specified an 88px padding on left and right.
The Results page uses `<Layout>` which has a configuration of  `px={5}` = 1.25rem = 20px.
I added a `<Box>` with padding `px="68px"` with a child component with shaded/clear background.. 
20px + 68px = 88px.

Designers have also specified a gap between sections. Since no values were given, I have set the value to be `py={5}`, meaning there is a gap of 40px between sections. This has been set at every section, which gives us the ability to change quicky should there be an updated design.

## link to Trello card or Github issue
https://codeforaustralia.slack.com/archives/C01DALXS62K/p1659504023077409


## How Has This Been Tested?
The Results page should have sections with light and dark backgrounds as shown below:
![image](https://user-images.githubusercontent.com/33863416/184047630-4d8ceb43-9c0f-4c3b-85e5-233ac6e74eef.png)

(note: dotted lines serve as guides only and have been removed from the committed code)

## Pull Request Checklist:
Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!
- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
