### PR TITLE
remove placeholder images for the last 2 sections of results page

### DIFF
--- a/pages/results.js
+++ b/pages/results.js
@@ -73,26 +73,6 @@ export default function Results({ data }) {
         <CommuteDistanceDistribution data={data} />
         <DistanceTravelledMode data={data["distance-travelled-by-mode"]} />
       </ResultContentSection>
-      <Flex
-        border="2px solid red"
-        width="100%"
-        p="20px"
-        mt="20px"
-        direction="column"
-      >
-        Transport type usage during work week
-        <Img
-          border="2px solid grey"
-          src="https://user-images.githubusercontent.com/88268603/174800762-b58ec331-79f7-4672-8685-83e49ea91877.png"
-        />
-      </Flex>
-      <Flex width="100%" p="20px" mt="20px" direction="column">
-        Transport type preference during work week
-        <Img
-          border="2px solid grey"
-          src="https://user-images.githubusercontent.com/88268603/174800922-8b09ebb9-f5b6-4b61-a396-50df26fc3229.png"
-        />
-      </Flex>
     </Layout>
   );
 }


### PR DESCRIPTION
## Overview of the Pull Request:
This PR removes the placeholder images in the last 2 sections of results page.
The last 2 sections will be omitted from the first release of results page.

## How Has This Been Tested?

The desktop view of results page should look like the screen shot below:
![image](https://user-images.githubusercontent.com/4408259/184569387-828248ce-16fa-4380-876d-f74d5b85964d.png)

### Out of scope
- have not fixed any other layout issues in this PR

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
