### PR TITLE
Remove highcharts credits

### DIFF
--- a/components/ResultsPageComponents/CommuteDays/CommuteDaysColumnChart.jsx
+++ b/components/ResultsPageComponents/CommuteDays/CommuteDaysColumnChart.jsx
@@ -34,6 +34,9 @@ export default function CommuteDaysColumnChart({ title, data }) {
       type: "column",
     },
     colors: ["#044B7F"],
+    credits: {
+      enabled: false
+    },
     tooltip: {
       pointFormat: "{point.y}%",
     },

--- a/components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistributionChart.jsx
+++ b/components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistributionChart.jsx
@@ -25,6 +25,9 @@ export default function CommuteDistanceDistributionChart({ title, data }) {
       height: 400,
     },
     colors: ["#044B7F"],
+    credits: {
+      enabled: false
+    },
     tooltip: {
       pointFormat: "{point.y}%",
     },

--- a/components/ResultsPageComponents/DistanceTravelledMode/DistanceTravelledModeChart.jsx
+++ b/components/ResultsPageComponents/DistanceTravelledMode/DistanceTravelledModeChart.jsx
@@ -9,6 +9,9 @@ export default function DistanceTravelledModeChart({ data }) {
     chart: {
       type: "bar",
     },
+    credits: {
+      enabled: false
+    },
     title: {
       text: undefined,
     },

--- a/components/ResultsPageComponents/SurveyOverview/SurveyOverview.jsx
+++ b/components/ResultsPageComponents/SurveyOverview/SurveyOverview.jsx
@@ -53,7 +53,6 @@ export default function SurveyOverview({
     totalEmissions: totalEmissions,
     totalTrips: totalTripCount,
   };
-  console.log(`results: ${JSON.stringify(surveyData)}`);
 
   const avgDistancePerTrip = (surveyData.totalDistance / surveyData.totalTrips).toPrecision(2);
   const avgEmissionPerTrip = (surveyData.totalEmissions / surveyData.totalTrips).toPrecision(2);

--- a/components/ResultsPageComponents/TopThree/TopThree.jsx
+++ b/components/ResultsPageComponents/TopThree/TopThree.jsx
@@ -13,7 +13,7 @@ export default function TopThree({
     let arr = topThree[key];
     arr.sort((a, b) => b.count - a.count);
   }
-  console.log("topThree: ", topThree);
+
   return (
     <Flex
       direction="column"

--- a/components/ResultsPageComponents/TopThree/TopThreeBarChart.jsx
+++ b/components/ResultsPageComponents/TopThree/TopThreeBarChart.jsx
@@ -123,6 +123,9 @@ export default function TopThreeBarChart({
       height: 250,
     },
     color: "#044B7F",
+    credits: {
+      enabled: false
+    },
     title: {
       text: title,
     },

--- a/components/ResultsPageComponents/TripCountAndTravelMethods/PieChart.jsx
+++ b/components/ResultsPageComponents/TripCountAndTravelMethods/PieChart.jsx
@@ -15,6 +15,9 @@ export default function PieChart({ title, data }) {
       plotShadow: false,
       type: "pie",
     },
+    credits: {
+      enabled: false
+    },
     tooltip: {
       pointFormat: "{series.name}: <b>{point.y}</b>",
     },


### PR DESCRIPTION
## Overview of the Pull Request:
This PR removes the `highcharts.com` credits text from **all** the charts in the results page:

![image](https://user-images.githubusercontent.com/4408259/184595735-86b48f81-0095-4aac-ade8-e1f256033e76.png)

This PR also removes a couple of `console.log` statements from the codebase.

## How Has This Been Tested?

- [ ] check that all credits texts at the bottom right corner of each chart has been removed from all the Highchart charts in the results page (see screenshot):
![image](https://user-images.githubusercontent.com/4408259/184595176-334e203e-1218-4bf8-b005-c85ddd77177b.png)

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
