### PR TITLE
update text in "work arrangement" section of results page

### DIFF
--- a/components/ResultsPageComponents/WorkArrangement/WorkArrangement.jsx
+++ b/components/ResultsPageComponents/WorkArrangement/WorkArrangement.jsx
@@ -34,13 +34,11 @@ export default function WorkArrangement({ workMode }) {
     >
       <Flex direction="column">
         <Text fontWeight={600} fontSize="33px" lineHeight="37px" py="15px">
-          Things to note before reading the results
+          Work Arrangement
         </Text>
         <Text fontSize="19px" py="15px">
-          The infographics below illustrate responders’ working arrangement
-          across the week. This information helps identify the percentage of
-          staff commuting to work in regular (on-site) and intermittent (hybrid)
-          patterns.
+          The information below illustrates respondents’ working arrangements
+          across the week and helps identify staff commuting habits.
         </Text>
         <Flex direction={["column", "row"]} align={["center", "flex-end"]}>
           <Flex width="30%" direction="column" py="20px">


### PR DESCRIPTION

## Overview of the Pull Request:
This PR updates the text content for the "work arrangement" section of the results page, to match the text content set forth in the [final figma design](https://www.figma.com/file/DEa98hc9qYB0meam2wtOau/Delta-D?node-id=2921%3A42965) (see screenshot below):

![image](https://user-images.githubusercontent.com/4408259/184779479-a3d494c7-ec54-4607-a98e-8480b47a0979.png)

## How Has This Been Tested?

Ensure the text in 'work arrangement' section of results page is aligned with figma design:
![image](https://user-images.githubusercontent.com/4408259/184779574-af3a0ef3-8986-4643-a92a-f8aeaf9a864a.png)

### Out of scope
- font settings has not been changed
- UI layout of this section has not been changed

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
