### PR TITLE
Travelling to Work Days - chart and section layout changes

### DIFF
--- a/components/ResultsPageComponents/CommuteDays/CommuteDays.jsx
+++ b/components/ResultsPageComponents/CommuteDays/CommuteDays.jsx
@@ -15,11 +15,11 @@ export default function CommuteDays({ data }) {
       py={["25px", "50px"]}
       justify="center"
     >
-      <Flex direction="column">
+      <Flex direction="column" width="100%">
         <Text fontWeight={600} fontSize="33px" lineHeight="37px" py="15px">
           Travelling to Work Days
         </Text>
-        <Text fontSize="19px" py="15px">
+        <Text fontSize="19px" py="15px" width="100%">
           The chart below shows the distribution of staff commute days
           throughout the week.
           <br />

--- a/components/ResultsPageComponents/CommuteDays/CommuteDaysColumnChart.jsx
+++ b/components/ResultsPageComponents/CommuteDays/CommuteDaysColumnChart.jsx
@@ -2,18 +2,6 @@ import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
 export default function CommuteDaysColumnChart({ title, data }) {
-  // data is of the following form:
-  // data = {
-  //     Mon: 10,
-  //     Tue: 20,
-  //     Wed: 25,
-  //     Thu: 20,
-  //     Fri: 10,
-  //     Sat: 15,
-  //     Sun: 0
-  // };
-  // console.log(JSON.stringify(data, ' ', null));
-
   const getMax = (a, b) => Math.max(a, b);
   const max = Object.values(data).reduce(getMax);
 
@@ -29,9 +17,11 @@ export default function CommuteDaysColumnChart({ title, data }) {
   const hichartsOpts = {
     title: {
       text: title,
+      style: { color: "#022640" },
     },
     chart: {
       type: "column",
+      height: 400,
     },
     colors: ["#044B7F"],
     tooltip: {
@@ -39,15 +29,19 @@ export default function CommuteDaysColumnChart({ title, data }) {
     },
     xAxis: {
       categories: Object.keys(data),
+      title: {
+        text: "Day",
+      },
     },
     yAxis: {
       min: 0,
       title: {
-        text: "% of staff that commuted",
+        text: "% of staff who commuted",
       },
     },
     series: [
       {
+        showInLegend: false,
         name: "Day",
         data: chartData,
       },

--- a/components/ResultsPageComponents/CommuteDays/CommuteDaysColumnChart.jsx
+++ b/components/ResultsPageComponents/CommuteDays/CommuteDaysColumnChart.jsx
@@ -1,5 +1,6 @@
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { Flex } from "@chakra-ui/react";
 
 export default function CommuteDaysColumnChart({ title, data }) {
   const getMax = (a, b) => Math.max(a, b);
@@ -48,5 +49,9 @@ export default function CommuteDaysColumnChart({ title, data }) {
     ],
   };
 
-  return <HighchartsReact highcharts={Highcharts} options={hichartsOpts} />;
+  return (
+    <Flex direction="column" maxWidth="634px" width="100%">
+      <HighchartsReact highcharts={Highcharts} options={hichartsOpts} />
+    </Flex>
+  );
 }


### PR DESCRIPTION

## Overview of the Pull Request:
- Edited chart description to match [Figma](https://www.figma.com/file/DEa98hc9qYB0meam2wtOau/Delta-D?node-id=2921%3A42962) design
- Changed y-axis label to "% of staff who commuted"
- Changed chart title to fit colours in design
- Changed bottom description to hide the blue dot and display just the text
- Edited layout to suit mobile view

## link to Trello card or Github issue

## How Has This Been Tested?
Text and chart should be left-justified in desktop view:

![image](https://user-images.githubusercontent.com/33863416/184794291-85229139-5c60-45b2-9d15-2afa2d0714ea.png)
(_Distribution of commute_ distance chart included for reference)

<br><br>
Text and chart should be centre in mobile view:
![image](https://user-images.githubusercontent.com/33863416/184794421-0bb524bd-2a92-480e-b502-62c1ed1abfd9.png)
(_Distribution of commute_ distance chart included for reference)

## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [X] Is your pull request up-to-date with `main` branch?
- [X] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [X] Have you written instructions on how to test that your changes work as expected?
- [X] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
