### PR TITLE
Distribution of Commute distance - removed duplicate 'km' units in x-axis values

### DIFF
--- a/components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistributionChart.jsx
+++ b/components/ResultsPageComponents/CommuteDistanceDistribution/CommuteDistanceDistributionChart.jsx
@@ -26,7 +26,7 @@ export default function CommuteDistanceDistributionChart({ title, data }) {
     },
     colors: ["#044B7F"],
     credits: {
-      enabled: false
+      enabled: false,
     },
     tooltip: {
       pointFormat: "{point.y}%",
@@ -38,7 +38,7 @@ export default function CommuteDistanceDistributionChart({ title, data }) {
       },
       labels: {
         formatter: function () {
-          return this.value + " km";
+          return this.value;
         },
       },
     },


### PR DESCRIPTION
## Overview of the Pull Request:
Removed duplicate "km" units in x-axis values

## link to Trello card or Github issue

## How Has This Been Tested?
There should be no duplicated "km" units in x-axis values:

![image](https://user-images.githubusercontent.com/33863416/184800851-76a67801-2f6f-4ec4-92fe-93a04284e139.png)


## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [ ] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [X] Is your pull request up-to-date with `main` branch?
- [X] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [X] Have you written instructions on how to test that your changes work as expected?
- [X] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
