### PR TITLE
Update color scheme for donut charts 

### DIFF
--- a/components/ResultsPageComponents/TripCountAndTravelMethods/PieChart.jsx
+++ b/components/ResultsPageComponents/TripCountAndTravelMethods/PieChart.jsx
@@ -1,9 +1,16 @@
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
-const colorDefaults = ["#044B7F", "#D69E2E", "#366F99", "#6893B2", "#9BB7CC", "#E6EEF3"];
+const colorDefaults = [
+  "#044B7F",
+  "#D69E2E",
+  "#366F99",
+  "#6893B2",
+  "#9BB7CC",
+  "#E6EEF3",
+];
 
-export default function PieChart({ title, data, colorList=colorDefaults }) {
+export default function PieChart({ title, data, colorList = colorDefaults }) {
   // converting data into the format readable by highcharts (rename key for count into y)
   const filteredData = data.forEach((item) => (item.y = item.count));
 
@@ -19,7 +26,7 @@ export default function PieChart({ title, data, colorList=colorDefaults }) {
     },
     colors: colorList,
     credits: {
-      enabled: false
+      enabled: false,
     },
     tooltip: {
       pointFormat: "{series.name}: <b>{point.y}</b>",

--- a/components/ResultsPageComponents/TripCountAndTravelMethods/PieChart.jsx
+++ b/components/ResultsPageComponents/TripCountAndTravelMethods/PieChart.jsx
@@ -1,7 +1,9 @@
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
-export default function PieChart({ title, data }) {
+const colorDefaults = ["#044B7F", "#D69E2E", "#366F99", "#6893B2", "#9BB7CC", "#E6EEF3"];
+
+export default function PieChart({ title, data, colorList=colorDefaults }) {
   // converting data into the format readable by highcharts (rename key for count into y)
   const filteredData = data.forEach((item) => (item.y = item.count));
 
@@ -15,6 +17,7 @@ export default function PieChart({ title, data }) {
       plotShadow: false,
       type: "pie",
     },
+    colors: colorList,
     credits: {
       enabled: false
     },

--- a/components/ResultsPageComponents/TripCountAndTravelMethods/PieChartComponent.jsx
+++ b/components/ResultsPageComponents/TripCountAndTravelMethods/PieChartComponent.jsx
@@ -1,7 +1,7 @@
 import { Flex } from "@chakra-ui/react";
 import PieChart from "./PieChart";
 
-export default function PieChartComponent({ title, data }) {
+export default function PieChartComponent({ title, data, colorList }) {
   return (
     <Flex
       width="520px"
@@ -12,7 +12,7 @@ export default function PieChartComponent({ title, data }) {
       justify="center"
       py="15px"
     >
-      <PieChart title={title} data={data} />
+      <PieChart title={title} data={data} colorList={colorList} />
     </Flex>
   );
 }

--- a/components/ResultsPageComponents/TripCountAndTravelMethods/TripCountAndTravelMethods.jsx
+++ b/components/ResultsPageComponents/TripCountAndTravelMethods/TripCountAndTravelMethods.jsx
@@ -67,7 +67,14 @@ export default function TripCountAndTravelMethods({ dataAboutTrips }) {
                   <PieChartComponent
                     title="Active-public-shared travel"
                     data={activePublicSharedTravel}
-                    colorList={["#044B7F", "#9BB7CC", "#366F99", "", "#6893B2", "#E6EEF3"]}
+                    colorList={[
+                      "#044B7F",
+                      "#9BB7CC",
+                      "#366F99",
+                      "",
+                      "#6893B2",
+                      "#E6EEF3",
+                    ]}
                   />
 
                   <PieChartComponent

--- a/components/ResultsPageComponents/TripCountAndTravelMethods/TripCountAndTravelMethods.jsx
+++ b/components/ResultsPageComponents/TripCountAndTravelMethods/TripCountAndTravelMethods.jsx
@@ -55,6 +55,7 @@ export default function TripCountAndTravelMethods({ dataAboutTrips }) {
               <PieChartComponent
                 title="Trip Count"
                 data={sharedVsIndividualData}
+                colorList={["#044B7F", "#D69E2E"]}
               />
 
               <Flex>
@@ -66,11 +67,13 @@ export default function TripCountAndTravelMethods({ dataAboutTrips }) {
                   <PieChartComponent
                     title="Active-public-shared travel"
                     data={activePublicSharedTravel}
+                    colorList={["#044B7F", "#9BB7CC", "#366F99", "", "#6893B2", "#E6EEF3"]}
                   />
 
                   <PieChartComponent
                     title="Individual travel"
                     data={individualTravel}
+                    colorList={["#9BB7CC", "#044B7F"]}
                   />
                 </Flex>
               </Flex>


### PR DESCRIPTION
## Overview of the Pull Request:
this PR updates the colors used in the donut charts (in the 'Trip count and Travel Methods' section of results page) to match the color scheme of the page, and align with the [final figma design](https://www.figma.com/file/DEa98hc9qYB0meam2wtOau/Delta-D?node-id=2921%3A42965) (see screenshot below):

![image](https://user-images.githubusercontent.com/4408259/185005102-daf67298-b457-429f-81ff-37740f41432a.png)

## link to Trello card or Github issue
https://trello.com/c/T943YdMY

## How Has This Been Tested?

check in the preview deployment that the color scheme of donut chart matches that of the figma design:
![image](https://user-images.githubusercontent.com/4408259/185005424-5293fb3f-0574-4218-8e79-f8c220c6330a.png)


## Pull Request Checklist:

Make sure the following checkboxes`[ ]` are checked with `x` before sending your PR -- thank you!

- [x] Have you included a link Trello card / Github issue and written sufficient description to help others review your work?
- [x] Is your pull request up-to-date with `main` branch?
- [x] Have you checked That code is well formatted? Did `npx prettier --check .` return no warnings/errors?
- [x] Have you written instructions on how to test that your changes work as expected?
- [x] Have you tested your work thoroughly on your local machine to ensure you are not breaking anything?
