### PR TITLE
fix responsiveness for copyright reference block

### DIFF
--- a/pages/howWeCalculate.js
+++ b/pages/howWeCalculate.js
@@ -273,7 +273,7 @@ export default function howWeCalculate() {
           borderRadius="15px"
           height="100%"
         >
-          <Flex background="#E5F4E3" borderRadius="inherit">
+          <Flex background="#E5F4E3" borderRadius="15px 15px 0px 0px">
             <Text fontWeight={700} fontSize="24px" lineHeight="29px" p="34px">
               Table of Contents
             </Text>

--- a/pages/howWeCalculate.js
+++ b/pages/howWeCalculate.js
@@ -208,7 +208,7 @@ export default function howWeCalculate() {
               </Text>
             </Flex>
             <Flex>
-              <Text fontSize="13px" fontStyle="italic">
+              <Text fontSize="13px" fontStyle="italic" width="100%">
                 {
                   "¹ 2018. Transport Strategy Refresh: Transport, Greenhouse Gas Emissions and Air Quality. [ebook] Melbourne: City of Melbourne, p.4. Available at: <https://s3.ap-southeast-2.amazonaws.com/hdp.au.prod.app.com-participate.files/6615/2948/1938/Transport_Strategy_Refresh__Zero_Net_Emissions_Strategy_-_Greenhouse_Gas_Emissions_and_Air_Quality.pdf> [Accessed 11 August 2022]."
                 }


### PR DESCRIPTION
## Overview of the Pull Request:

Small fixes to the How We Calculate Page:

1. Fix the responsiveness of copyright reference block

Before:
![image](https://user-images.githubusercontent.com/88268603/186375052-28521c72-3df0-47b3-939f-ee7632076a57.png)

After: 
![image](https://user-images.githubusercontent.com/88268603/186374974-0d5096cb-ea36-48e5-b755-7fdd69faf089.png)

2. Fix the border radius for contents header:

Before: 
![image](https://user-images.githubusercontent.com/88268603/186378875-fc64f849-02a4-4430-bbbb-39fd7f610fec.png)

After:
![image](https://user-images.githubusercontent.com/88268603/186378954-33f43e73-a0b0-4dee-a3dc-eebc21277f4f.png)
